### PR TITLE
Recalculate all outstanding floating interest rate changes

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/mapper/LoanTermVariationsMapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/mapper/LoanTermVariationsMapper.java
@@ -131,13 +131,16 @@ public class LoanTermVariationsMapper {
         if (loan.getLoanProduct().isLinkedToFloatingInterestRate()) {
             floatingRateDTO.resetInterestRateDiff();
             Collection<FloatingRatePeriodData> applicableRates = loan.getLoanProduct().fetchInterestRates(floatingRateDTO);
-            LocalDate interestRateStartDate = DateUtils.getBusinessLocalDate();
+            LocalDate today = DateUtils.getBusinessLocalDate();
+            LocalDate latestStartDate = LocalDate.MIN;
             for (FloatingRatePeriodData periodData : applicableRates) {
                 LoanTermVariationsData loanTermVariation = new LoanTermVariationsData(
                         LoanEnumerations.loanVariationType(LoanTermVariationType.INTEREST_RATE), periodData.getFromDateAsLocalDate(),
                         periodData.getInterestRate(), dateValue, isSpecificToInstallment);
-                if (!DateUtils.isBefore(interestRateStartDate, periodData.getFromDateAsLocalDate())) {
-                    interestRateStartDate = periodData.getFromDateAsLocalDate();
+                boolean beforeToday = DateUtils.isBefore(periodData.getFromDateAsLocalDate(), today);
+                boolean afterLatest = DateUtils.isAfter(periodData.getFromDateAsLocalDate(), latestStartDate);
+                if (beforeToday && afterLatest) {
+                    latestStartDate = periodData.getFromDateAsLocalDate();
                     interestRate = periodData.getInterestRate();
                 }
                 loanTermVariations.add(loanTermVariation);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -2060,10 +2060,12 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                 -- for past due interest recalculation
                 LEFT JOIN m_loan_recalculation_details rcd ON rcd.loan_id = l.id
                 -- For Floating rate changes
-                LEFT JOIN m_product_loan_floating_rates pfr
-                    ON l.product_id = pfr.loan_product_id AND l.is_floating_interest_rate = TRUE
+                LEFT JOIN m_product_loan_floating_rates pfr ON l.product_id = pfr.loan_product_id
                 LEFT JOIN m_floating_rates fr ON pfr.floating_rates_id = fr.id
-                LEFT JOIN m_floating_rates_periods frp ON fr.id = frp.floating_rates_id
+                LEFT JOIN m_floating_rates_periods frp
+                    ON fr.id = frp.floating_rates_id AND frp.from_date <= ?
+                    AND ((l.interest_recalcualated_on IS NULL AND l.disbursedon_date < frp.from_date
+                        OR l.interest_recalcualated_on < frp.from_date))
                 LEFT JOIN m_loan_reschedule_request lrr ON lrr.loan_id = l.id
                 -- this is to identify the applicable rates when base rate is changed
                 LEFT JOIN m_floating_rates bfr ON bfr.is_base_lending_rate = TRUE
@@ -2081,8 +2083,9 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                         -- float rate changes
                         (fr.is_active = TRUE
                             AND frp.is_active = TRUE
-                            AND (frp.created_date >= ?
-                                 OR (bfrp.id IS NOT NULL
+                            AND ((l.interest_recalcualated_on IS NULL AND l.disbursedon_date < frp.from_date)
+                                OR l.interest_recalcualated_on < frp.from_date
+                                OR (bfrp.id IS NOT NULL
                                      AND frp.is_differential_to_base_lending_rate = TRUE
                                      AND frp.from_date >= bfrp.from_date))
                             AND lrr.loan_id IS NULL)
@@ -2093,8 +2096,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
             LocalDate currentdate = DateUtils.getBusinessLocalDate();
             // will look only for yesterday modified rates
             LocalDate yesterday = DateUtils.getBusinessLocalDate().minusDays(1);
-            return this.jdbcTemplate.queryForList(sql, Long.class, yesterday, LoanStatus.ACTIVE.getValue(), currentdate, currentdate,
-                    currentdate, yesterday);
+            return this.jdbcTemplate.queryForList(sql, Long.class, currentdate, yesterday, LoanStatus.ACTIVE.getValue(),
+                    currentdate, currentdate, currentdate);
         } catch (final EmptyResultDataAccessException e) {
             return null;
         }
@@ -2116,10 +2119,12 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                 -- for past due interest recalculation
                 LEFT JOIN m_loan_recalculation_details rcd ON rcd.loan_id = l.id
                 -- For Floating rate changes
-                LEFT JOIN m_product_loan_floating_rates pfr
-                    ON l.product_id = pfr.loan_product_id AND l.is_floating_interest_rate = TRUE
+                LEFT JOIN m_product_loan_floating_rates pfr ON l.product_id = pfr.loan_product_id
                 LEFT JOIN m_floating_rates fr ON pfr.floating_rates_id = fr.id
-                LEFT JOIN m_floating_rates_periods frp ON fr.id = frp.floating_rates_id
+                LEFT JOIN m_floating_rates_periods frp
+                    ON fr.id = frp.floating_rates_id AND frp.from_date <= ?
+                    AND ((l.interest_recalcualated_on IS NULL AND l.disbursedon_date < frp.from_date
+                        OR l.interest_recalcualated_on < frp.from_date))
                 LEFT JOIN m_loan_reschedule_request lrr ON lrr.loan_id = l.id
                 -- this is to identify the applicable rates when base rate is changed
                 LEFT JOIN m_floating_rates bfr ON bfr.is_base_lending_rate = TRUE
@@ -2135,7 +2140,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                         OR
                          (fr.is_active = TRUE
                              AND frp.is_active = TRUE
-                             AND (frp.created_date >= ?
+                             AND ((l.interest_recalcualated_on IS NULL AND l.disbursedon_date < frp.from_date)
+                                  OR l.interest_recalcualated_on < frp.from_date
                                   OR (bfrp.id IS NOT NULL
                                       AND frp.is_differential_to_base_lending_rate = TRUE
                                       AND frp.from_date >= bfrp.from_date))
@@ -2147,8 +2153,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                 LIMIT ?
                 """;
         try {
-            return Collections.synchronizedList(this.jdbcTemplate.queryForList(sql, Long.class, yesterday, LoanStatus.ACTIVE.getValue(),
-                    currentdate, currentdate, currentdate, yesterday, maxLoanIdInList, officeHierarchy, pageSize));
+            return Collections.synchronizedList(this.jdbcTemplate.queryForList(sql, Long.class, currentdate, yesterday, LoanStatus.ACTIVE.getValue(),
+                    currentdate, currentdate, currentdate, maxLoanIdInList, officeHierarchy, pageSize));
         } catch (final EmptyResultDataAccessException e) {
             return null;
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanUtilService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanUtilService.java
@@ -204,7 +204,8 @@ public class LoanUtilService {
     private FloatingRateDTO constructFloatingRateDTO(final Loan loan) {
         FloatingRateDTO floatingRateDTO = null;
         if (loan.loanProduct().isLinkedToFloatingInterestRate()) {
-            boolean isFloatingInterestRate = loan.getIsFloatingInterestRate();
+            // The loan is considered to have a floating rate if linked to a floating rate
+            boolean isFloatingInterestRate = true;
             BigDecimal interestRateDiff = loan.getInterestRateDifferential();
             List<FloatingRatePeriodData> baseLendingRatePeriods = null;
             try {


### PR DESCRIPTION
The previous logic only looked for floating rate periods created the
previous day, and was reading from an unused column. With this change:

- fetchLoansForInterestRecalculation() will find any loans linked to a
  floating rate for which interest has not been recalculated or for
  which a new period has started since the last interest recalculation
- constructFloatingRateDTO() will consider any loan linked to a
  floating rate as having a floating rate, rather that only those
  explicitly marked as such
- constructFloatingInterestRates() will use the most recent interest rate