### PR TITLE
Per-transfer transactions in jobs

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/jobs/exception/TruncatedJobExecutionException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/jobs/exception/TruncatedJobExecutionException.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.infrastructure.jobs.exception;
+
+import java.util.List;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TruncatedJobExecutionException extends JobExecutionException {
+
+    private static final int MAX_ERROR_LOG_LENGTH = 60000; // Fit 64k column size
+
+    public TruncatedJobExecutionException(List<Throwable> problems) {
+        super(problems);
+    }
+
+    @Override
+    public String getMessage() {
+        String truncated = truncateMessage(super.getMessage());
+        int totalErrors = getCauses().size();
+        return truncated + "\n\n[ERROR LOG TRUNCATED - Total errors: " + totalErrors +
+                " - Full details logged separately]";
+    }
+
+    @Override
+    public void printStackTrace() {
+        log.error("{}", getMessage());
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        s.println(getMessage());
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        s.println(getMessage());
+    }
+
+    private String truncateMessage(String message) {
+        byte[] fullBytes = message.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        String truncatedMessage;
+        if (fullBytes.length <= MAX_ERROR_LOG_LENGTH) {
+            truncatedMessage = message;
+        } else {
+            // Find the largest substring whose UTF-8 bytes fit within the limit
+            int end = message.length();
+            int low = 0, high = end;
+            while (low < high) {
+                int mid = (low + high + 1) / 2;
+                String sub = message.substring(0, mid);
+                if (sub.getBytes(java.nio.charset.StandardCharsets.UTF_8).length <= MAX_ERROR_LOG_LENGTH) {
+                    low = mid;
+                } else {
+                    high = mid - 1;
+                }
+            }
+            truncatedMessage = message.substring(0, low);
+        }
+        return truncatedMessage;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteStandingInstructionsConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteStandingInstructionsConfig.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
 public class ExecuteStandingInstructionsConfig {
@@ -49,6 +50,8 @@ public class ExecuteStandingInstructionsConfig {
     private DatabaseSpecificSQLGenerator sqlGenerator;
     @Autowired
     private AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     @Bean
     protected Step executeStandingInstructionsStep() {
@@ -65,6 +68,6 @@ public class ExecuteStandingInstructionsConfig {
     @Bean
     public ExecuteStandingInstructionsTasklet executeStandingInstructionsTasklet() {
         return new ExecuteStandingInstructionsTasklet(standingInstructionReadPlatformService, jdbcTemplate, sqlGenerator,
-                accountTransfersWritePlatformService);
+                accountTransfersWritePlatformService, transactionTemplate);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteStandingInstructionsTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteStandingInstructionsTasklet.java
@@ -30,7 +30,7 @@ import org.apache.fineract.infrastructure.core.exception.AbstractPlatformService
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
-import org.apache.fineract.infrastructure.jobs.exception.JobExecutionException;
+import org.apache.fineract.infrastructure.jobs.exception.TruncatedJobExecutionException;
 import org.apache.fineract.portfolio.account.data.AccountTransferDTO;
 import org.apache.fineract.portfolio.account.data.StandingInstructionData;
 import org.apache.fineract.portfolio.account.data.StandingInstructionDuesData;
@@ -49,6 +49,11 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.NonNull;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -58,6 +63,7 @@ public class ExecuteStandingInstructionsTasklet implements Tasklet {
     private final JdbcTemplate jdbcTemplate;
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
@@ -113,26 +119,35 @@ public class ExecuteStandingInstructionsTasklet implements Tasklet {
                 final boolean transferCompleted = transferAmount(errors, accountTransferDTO, data.getId());
 
                 if (transferCompleted) {
-                    final String updateQuery = "UPDATE m_account_transfer_standing_instructions SET last_run_date = ? where id = ?";
-                    jdbcTemplate.update(updateQuery, transactionDate, data.getId());
+                    updateLastRunDate(transactionDate, data.getId());
                 }
 
             }
         }
         if (!errors.isEmpty()) {
-            throw new JobExecutionException(errors);
+            log.error("ExecuteStandingInstructions job completed with {} errors out of {} total instructions",
+                    errors.size(), instructionData != null ? instructionData.size() : 0);
+            throw new TruncatedJobExecutionException(errors);
         }
         return RepeatStatus.FINISHED;
     }
 
     private boolean transferAmount(final List<Throwable> errors, final AccountTransferDTO accountTransferDTO, final Long instructionId) {
-        boolean transferCompleted = true;
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        boolean transferCompleted = false;
         StringBuilder errorLog = new StringBuilder();
-        StringBuilder updateQuery = new StringBuilder(
-                "INSERT INTO m_account_transfer_standing_instructions_history (standing_instruction_id, " + sqlGenerator.escape("status")
-                        + ", amount,execution_time, error_log) VALUES (");
+
         try {
-            accountTransfersWritePlatformService.transferFunds(accountTransferDTO);
+            transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+                @Override
+                protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
+                    accountTransfersWritePlatformService.transferFunds(accountTransferDTO);
+                    log.debug("Successfully transferred standing instruction {} for amount {}",
+                            instructionId, accountTransferDTO.getTransactionAmount());
+                }
+            });
+            transferCompleted = true;
         } catch (final PlatformApiDataValidationException e) {
             errors.add(new Exception("Validation exception while transfering funds for standing Instruction id" + instructionId + " from "
                     + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId(), e));
@@ -149,20 +164,28 @@ public class ExecuteStandingInstructionsTasklet implements Tasklet {
             errors.add(new Exception("Unhandled System Exception while trasfering funds for standing Instruction id" + instructionId
                     + " from " + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId(), e));
             errorLog.append("Exception while trasfering funds ").append(e.getMessage());
+        }
 
-        }
+        logTransferHistory(instructionId, accountTransferDTO.getTransactionAmount(), transferCompleted, errorLog.toString());
+
+        return transferCompleted;
+    }
+
+    private void updateLastRunDate(LocalDate transactionDate, Long instructionId) {
+        final String updateQuery = "UPDATE m_account_transfer_standing_instructions SET last_run_date = ? where id = ?";
+        jdbcTemplate.update(updateQuery, transactionDate, instructionId);
+    }
+
+    private void logTransferHistory(Long instructionId, BigDecimal amount, boolean success, String errorLog) {
+        StringBuilder updateQuery = new StringBuilder(
+                "INSERT INTO m_account_transfer_standing_instructions_history (standing_instruction_id, " + sqlGenerator.escape("status")
+                        + ", amount,execution_time, error_log) VALUES (");
         updateQuery.append(instructionId).append(",");
-        if (errorLog.length() > 0) {
-            transferCompleted = false;
-            updateQuery.append("'failed'").append(",");
-        } else {
-            updateQuery.append("'success'").append(",");
-        }
-        updateQuery.append(accountTransferDTO.getTransactionAmount().doubleValue());
+        updateQuery.append(success ? "'success'" : "'failed'").append(",");
+        updateQuery.append(amount.doubleValue());
         updateQuery.append(", now(),");
         updateQuery.append("'").append(errorLog).append("')");
         jdbcTemplate.update(updateQuery.toString());
-        return transferCompleted;
     }
 
     public boolean isDueForTransfer(StandingInstructionDuesData standingInstructionDuesData) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansConfig.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
 public class TransferFeeChargeForLoansConfig {
@@ -46,6 +47,8 @@ public class TransferFeeChargeForLoansConfig {
     private AccountAssociationsReadPlatformService accountAssociationsReadPlatformService;
     @Autowired
     private AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     @Bean
     protected Step transferFeeChargeForLoansStep() {
@@ -55,13 +58,15 @@ public class TransferFeeChargeForLoansConfig {
 
     @Bean
     public Job transferFeeChargeForLoansJob() {
-        return new JobBuilder(JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), jobRepository).start(transferFeeChargeForLoansStep())
+        return new JobBuilder(JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), jobRepository)
+                .start(transferFeeChargeForLoansStep())
                 .incrementer(new RunIdIncrementer()).build();
     }
 
     @Bean
     public TransferFeeChargeForLoansTasklet transferFeeChargeForLoansTasklet() {
-        return new TransferFeeChargeForLoansTasklet(loanChargeReadPlatformService, accountAssociationsReadPlatformService,
-                accountTransfersWritePlatformService);
+        return new TransferFeeChargeForLoansTasklet(loanChargeReadPlatformService,
+                accountAssociationsReadPlatformService,
+                accountTransfersWritePlatformService, transactionTemplate);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansTasklet.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.infrastructure.jobs.exception.JobExecutionException;
+import org.apache.fineract.infrastructure.jobs.exception.TruncatedJobExecutionException;
 import org.apache.fineract.portfolio.account.PortfolioAccountType;
 import org.apache.fineract.portfolio.account.data.AccountTransferDTO;
 import org.apache.fineract.portfolio.account.data.PortfolioAccountData;
@@ -100,7 +100,9 @@ public class TransferFeeChargeForLoansTasklet implements Tasklet {
             }
         }
         if (!errors.isEmpty()) {
-            throw new JobExecutionException(errors);
+            log.error("TransferFeeChargeForLoans job completed with {} errors out of {} total charges",
+                    errors.size(), chargeDatas != null ? chargeDatas.size() : 0);
+            throw new TruncatedJobExecutionException(errors);
         }
         return RepeatStatus.FINISHED;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/transferfeechargeforloans/TransferFeeChargeForLoansTasklet.java
@@ -42,6 +42,11 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.lang.NonNull;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -50,6 +55,7 @@ public class TransferFeeChargeForLoansTasklet implements Tasklet {
     private final LoanChargeReadPlatformService loanChargeReadPlatformService;
     private final AccountAssociationsReadPlatformService accountAssociationsReadPlatformService;
     private final AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
@@ -100,8 +106,19 @@ public class TransferFeeChargeForLoansTasklet implements Tasklet {
     }
 
     private void transferFeeCharge(final AccountTransferDTO accountTransferDTO, List<Throwable> errors) {
+        // Configure transaction template to use REQUIRES_NEW propagation
+        // This ensures each transfer runs in its own transaction
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
         try {
-            accountTransfersWritePlatformService.transferFunds(accountTransferDTO);
+            transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+                @Override
+                protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
+                    accountTransfersWritePlatformService.transferFunds(accountTransferDTO);
+                    log.debug("Successfully transferred fee charge {} for loan id {}",
+                            accountTransferDTO.getChargeId(), accountTransferDTO.getToAccountId());
+                }
+            });
         } catch (RuntimeException e) {
             log.error("Exception while paying charge {} for loan id {}", accountTransferDTO.getChargeId(),
                     accountTransferDTO.getToAccountId(), e);

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteOverdueAndCurrentStandingInstructionsTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteOverdueAndCurrentStandingInstructionsTest.java
@@ -49,14 +49,14 @@ public class ExecuteOverdueAndCurrentStandingInstructionsTest {
 
     @Test
     public void testAcceptPreviousDateAsDue() {
-        ExecuteStandingInstructionsTasklet tasklet = new ExecuteStandingInstructionsTasklet(null, null, null, null);
+        ExecuteStandingInstructionsTasklet tasklet = new ExecuteStandingInstructionsTasklet(null, null, null, null, null);
         boolean isDueForTransfer = tasklet.isDueForTransfer(new StandingInstructionDuesData(previousDate, BigDecimal.ONE));
         assertThat(isDueForTransfer).isTrue().describedAs("Earlier instructions are accepted as due");
     }
 
     @Test
     public void testAcceptCurrentDateAsDue() {
-        ExecuteStandingInstructionsTasklet tasklet = new ExecuteStandingInstructionsTasklet(null, null, null, null);
+        ExecuteStandingInstructionsTasklet tasklet = new ExecuteStandingInstructionsTasklet(null, null, null, null, null);
         boolean isDueForTransfer = tasklet.isDueForTransfer(new StandingInstructionDuesData(currentDate, BigDecimal.ONE));
         assertThat(isDueForTransfer).isTrue().describedAs("Current day instructions are accepted as due");
     }


### PR DESCRIPTION
This updates the ExecuteStandingInstruction and TransferFeeChargeForLoans jobs to use a transaction for each individual transfer, rather than the entire job, allowing a subset of transactions to fail without causing the rest of the job to fail.