### PR TITLE
Add periodic loan charges via mnzl job

### DIFF
--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlApplyPeriodicLoanChargesTasklet.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlApplyPeriodicLoanChargesTasklet.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.job;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.jobs.exception.TruncatedJobExecutionException;
+import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.lang.NonNull;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MnzlApplyPeriodicLoanChargesTasklet implements Tasklet {
+
+    private final MnzlPeriodicLoanChargeCandidateReadService candidateReadService;
+    private final LoanChargeWritePlatformService loanChargeWritePlatformService;
+    private final TransactionTemplate transactionTemplate;
+
+    @Override
+    public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
+        final Collection<Long> candidateLoanIds = candidateReadService
+                .retrieveLoanIdsWithDuePeriodicCharges(DateUtils.getBusinessLocalDate());
+        final Set<Long> uniqueLoanIds = new LinkedHashSet<>(candidateLoanIds);
+        final List<Throwable> errors = new ArrayList<>();
+
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        for (final Long loanId : uniqueLoanIds) {
+            try {
+                transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+
+                    @Override
+                    protected void doInTransactionWithoutResult(@NonNull final TransactionStatus status) {
+                        loanChargeWritePlatformService.applyPeriodicChargesForLoan(loanId);
+                    }
+                });
+            } catch (final RuntimeException e) {
+                log.error("Apply periodic loan charges failed for account {}", loanId, e);
+                errors.add(e);
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new TruncatedJobExecutionException(errors);
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlJobName.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlJobName.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.job;
+
+public enum MnzlJobName {
+
+    APPLY_PERIODIC_LOAN_CHARGES("Apply Periodic Loan Charges");
+
+    private final String name;
+
+    MnzlJobName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+}

--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlJobNameConfig.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlJobNameConfig.java
@@ -35,6 +35,8 @@ public class MnzlJobNameConfig {
     public JobNameProvider mnzlJobNameProvider() {
         return new SimpleJobNameProvider(
                 List.of(new JobNameData(JobName.EXECUTE_STANDING_INSTRUCTIONS.name(), JobName.EXECUTE_STANDING_INSTRUCTIONS.toString()),
-                        new JobNameData(JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.toString())));
+                        new JobNameData(JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.toString()),
+                        new JobNameData(MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.name(),
+                                MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.toString())));
     }
 }

--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlJobNameConfig.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlJobNameConfig.java
@@ -33,10 +33,9 @@ public class MnzlJobNameConfig {
 
     @Bean
     public JobNameProvider mnzlJobNameProvider() {
-        return new SimpleJobNameProvider(
-                List.of(new JobNameData(JobName.EXECUTE_STANDING_INSTRUCTIONS.name(), JobName.EXECUTE_STANDING_INSTRUCTIONS.toString()),
-                        new JobNameData(JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.toString()),
-                        new JobNameData(MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.name(),
-                                MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.toString())));
+        return new SimpleJobNameProvider(List.of(
+                new JobNameData(JobName.EXECUTE_STANDING_INSTRUCTIONS.name(), JobName.EXECUTE_STANDING_INSTRUCTIONS.toString()),
+                new JobNameData(JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.toString()),
+                new JobNameData(MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.name(), MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.toString())));
     }
 }

--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlPeriodicLoanChargeCandidateReadService.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlPeriodicLoanChargeCandidateReadService.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.job;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.portfolio.charge.domain.ChargeAppliesTo;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RequiredArgsConstructor
+public class MnzlPeriodicLoanChargeCandidateReadService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public Collection<Long> retrieveLoanIdsWithDuePeriodicCharges(final LocalDate businessDate) {
+        final String sql = """
+                SELECT DISTINCT l.id
+                FROM m_loan l
+                INNER JOIN m_product_loan_charge plc ON plc.product_loan_id = l.product_id
+                INNER JOIN m_charge c ON c.id = plc.charge_id
+                WHERE l.loan_status_id IN (?, ?)
+                  AND l.is_charged_off = FALSE
+                  AND c.is_deleted = FALSE
+                  AND c.is_active = TRUE
+                  AND c.charge_applies_to_enum = ?
+                  AND c.charge_time_enum = ?
+                  AND COALESCE(l.expected_firstrepaymenton_date, (
+                      SELECT MIN(rps.duedate)
+                      FROM m_loan_repayment_schedule rps
+                      WHERE rps.loan_id = l.id
+                        AND COALESCE(rps.is_down_payment, FALSE) = FALSE
+                  )) <= ?
+                """;
+        try {
+            return this.jdbcTemplate.queryForList(sql, Long.class, LoanStatus.ACTIVE.getValue(), LoanStatus.OVERPAID.getValue(),
+                    ChargeAppliesTo.LOAN.getValue(), ChargeTimeType.LOAN_PERIODIC.getValue(), businessDate);
+        } catch (final EmptyResultDataAccessException e) {
+            return List.of();
+        }
+    }
+}

--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlPeriodicLoanChargesJobConfiguration.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlPeriodicLoanChargesJobConfiguration.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.job;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "mnzl.loan.job.enabled", havingValue = "true", matchIfMissing = true)
+public class MnzlPeriodicLoanChargesJobConfiguration {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Bean
+    public MnzlPeriodicLoanChargeCandidateReadService mnzlPeriodicLoanChargeCandidateReadService(final JdbcTemplate jdbcTemplate) {
+        return new MnzlPeriodicLoanChargeCandidateReadService(jdbcTemplate);
+    }
+
+    @Bean
+    public MnzlApplyPeriodicLoanChargesTasklet mnzlApplyPeriodicLoanChargesTasklet(
+            final MnzlPeriodicLoanChargeCandidateReadService candidateReadService,
+            final LoanChargeWritePlatformService loanChargeWritePlatformService, final TransactionTemplate transactionTemplate) {
+        return new MnzlApplyPeriodicLoanChargesTasklet(candidateReadService, loanChargeWritePlatformService, transactionTemplate);
+    }
+
+    @Bean
+    protected Step mnzlApplyPeriodicLoanChargesStep(final MnzlApplyPeriodicLoanChargesTasklet tasklet) {
+        return new StepBuilder(MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.name(), jobRepository).tasklet(tasklet, transactionManager).build();
+    }
+
+    @Bean
+    public Job mnzlApplyPeriodicLoanChargesJob(final MnzlApplyPeriodicLoanChargesTasklet tasklet) {
+        return new JobBuilder(MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.name(), jobRepository)
+                .start(mnzlApplyPeriodicLoanChargesStep(tasklet)).incrementer(new RunIdIncrementer()).build();
+    }
+}

--- a/custom/mnzl/loan/job/src/main/resources/db/custom-changelog/0001_mnzl_loan_job.xml
+++ b/custom/mnzl/loan/job/src/main/resources/db/custom-changelog/0001_mnzl_loan_job.xml
@@ -35,4 +35,33 @@
             <where>name='Transfer Fee For Loans From Savings' and (short_name is null or short_name='')</where>
         </update>
     </changeSet>
+
+    <changeSet author="mnzl" id="3">
+        <insert tableName="job">
+            <column name="name" value="Apply Periodic Loan Charges"/>
+            <column name="display_name" value="Apply Periodic Loan Charges"/>
+            <column name="short_name" value="LA_PLC"/>
+            <column name="cron_expression" value="0 1 0 1/1 * ? *"/>
+            <column name="create_time" valueDate="${current_datetime}"/>
+            <column name="task_priority" valueNumeric="5"/>
+            <column name="group_name"/>
+            <column name="previous_run_start_time"/>
+            <column name="job_key" value="Apply Periodic Loan Charges _ DEFAULT"/>
+            <column name="initializing_errorlog"/>
+            <column name="is_active" valueBoolean="false"/>
+            <column name="currently_running" valueBoolean="false"/>
+            <column name="updates_allowed" valueBoolean="true"/>
+            <column name="scheduler_group" valueNumeric="0"/>
+            <column name="is_misfired" valueBoolean="false"/>
+            <column name="node_id" valueNumeric="1"/>
+            <column name="is_mismatched_job" valueBoolean="true"/>
+        </insert>
+    </changeSet>
+
+    <changeSet author="mnzl" id="4">
+        <update tableName="job">
+            <column name="short_name" value="LA_PLC"/>
+            <where>name='Apply Periodic Loan Charges'</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>

--- a/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlApplyPeriodicLoanChargesTaskletTest.java
+++ b/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlApplyPeriodicLoanChargesTaskletTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.job;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.jobs.exception.TruncatedJobExecutionException;
+import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class MnzlApplyPeriodicLoanChargesTaskletTest {
+
+    @Mock
+    private MnzlPeriodicLoanChargeCandidateReadService candidateReadService;
+
+    @Mock
+    private LoanChargeWritePlatformService loanChargeWritePlatformService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @Mock
+    private StepContribution stepContribution;
+
+    @Mock
+    private ChunkContext chunkContext;
+
+    @Mock
+    private TransactionStatus transactionStatus;
+
+    @Test
+    void executeProcessesEachCandidateLoanOnce() throws Exception {
+        when(candidateReadService.retrieveLoanIdsWithDuePeriodicCharges(any(LocalDate.class))).thenReturn(List.of(11L, 11L, 17L));
+        when(transactionTemplate.execute(any())).thenAnswer(
+                invocation -> invocation.<TransactionCallback<Object>>getArgument(0).doInTransaction(transactionStatus));
+        MnzlApplyPeriodicLoanChargesTasklet underTest = new MnzlApplyPeriodicLoanChargesTasklet(candidateReadService,
+                loanChargeWritePlatformService, transactionTemplate);
+
+        try (MockedStatic<DateUtils> mockedDateUtils = org.mockito.Mockito.mockStatic(DateUtils.class)) {
+            mockedDateUtils.when(DateUtils::getBusinessLocalDate).thenReturn(LocalDate.of(2026, 3, 12));
+
+            RepeatStatus result = underTest.execute(stepContribution, chunkContext);
+
+            assertEquals(RepeatStatus.FINISHED, result);
+        }
+
+        verify(transactionTemplate, times(1)).setPropagationBehavior(anyInt());
+        verify(loanChargeWritePlatformService, times(1)).applyPeriodicChargesForLoan(11L);
+        verify(loanChargeWritePlatformService, times(1)).applyPeriodicChargesForLoan(17L);
+    }
+
+    @Test
+    void executeContinuesAfterLoanFailureAndThrowsTruncatedExecutionException() {
+        when(candidateReadService.retrieveLoanIdsWithDuePeriodicCharges(any(LocalDate.class))).thenReturn(List.of(11L, 13L, 17L));
+        when(transactionTemplate.execute(any())).thenAnswer(
+                invocation -> invocation.<TransactionCallback<Object>>getArgument(0).doInTransaction(transactionStatus));
+        doThrow(new IllegalStateException("boom")).when(loanChargeWritePlatformService).applyPeriodicChargesForLoan(13L);
+        MnzlApplyPeriodicLoanChargesTasklet underTest = new MnzlApplyPeriodicLoanChargesTasklet(candidateReadService,
+                loanChargeWritePlatformService, transactionTemplate);
+
+        try (MockedStatic<DateUtils> mockedDateUtils = org.mockito.Mockito.mockStatic(DateUtils.class)) {
+            mockedDateUtils.when(DateUtils::getBusinessLocalDate).thenReturn(LocalDate.of(2026, 3, 12));
+
+            assertThatThrownBy(() -> underTest.execute(stepContribution, chunkContext))
+                    .isInstanceOf(TruncatedJobExecutionException.class);
+        }
+
+        verify(loanChargeWritePlatformService, times(1)).applyPeriodicChargesForLoan(11L);
+        verify(loanChargeWritePlatformService, times(1)).applyPeriodicChargesForLoan(13L);
+        verify(loanChargeWritePlatformService, times(1)).applyPeriodicChargesForLoan(17L);
+    }
+}

--- a/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlApplyPeriodicLoanChargesTaskletTest.java
+++ b/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlApplyPeriodicLoanChargesTaskletTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlJobNameConfigTest.java
+++ b/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlJobNameConfigTest.java
@@ -20,6 +20,8 @@ package co.mnzl.fineract.custom.loan.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.fineract.infrastructure.jobs.service.JobName;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +32,17 @@ class MnzlJobNameConfigTest {
         var provider = new MnzlJobNameConfig().mnzlJobNameProvider();
 
         assertThat(provider.provide()).extracting("enumStyleName").contains(JobName.EXECUTE_STANDING_INSTRUCTIONS.name(),
-                JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name());
+                JobName.TRANSFER_FEE_CHARGE_FOR_LOANS.name(), MnzlJobName.APPLY_PERIODIC_LOAN_CHARGES.name());
+    }
+
+    @Test
+    void changelogContainsPeriodicLoanChargeJobMetadata() throws IOException {
+        try (var inputStream = getClass().getClassLoader().getResourceAsStream("db/custom-changelog/0001_mnzl_loan_job.xml")) {
+            assertThat(inputStream).isNotNull();
+            final String changelog = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertThat(changelog).contains("Apply Periodic Loan Charges");
+            assertThat(changelog).contains("LA_PLC");
+        }
     }
 }

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
@@ -268,6 +268,7 @@ public class Charge extends AbstractPersistableCustom<Long> {
                 baseDataValidator.reset().parameter(CHARGE_TIME_PARAM_NAME).value(this.chargeTimeType)
                         .failWithCodeNoParameterAddedToErrorCode("not.allowed.charge.time.for.loan");
             }
+            validatePeriodicLoanChargeConfiguration(baseDataValidator, chargeTime, feeOnMonthDay, feeInterval, feeFrequency);
         }
 
         if (isPercentageOfDisbursementAmount() || isPercentageOfApprovedAmount()) {
@@ -588,6 +589,9 @@ public class Charge extends AbstractPersistableCustom<Long> {
             baseDataValidator.reset().parameter(FEE_INTERVAL_PARAM_NAME).value(this.feeInterval).notNull();
         }
 
+        validatePeriodicLoanChargeConfiguration(baseDataValidator, ChargeTimeType.fromInt(this.chargeTimeType), getFeeOnMonthDay(),
+                this.feeInterval, this.feeFrequency);
+
         final String penaltyParamName = "penalty";
         if (command.isChangeInBooleanParameterNamed(penaltyParamName, this.penalty)) {
             final boolean newValue = command.booleanPrimitiveValueOfParameterNamed(penaltyParamName);
@@ -711,6 +715,10 @@ public class Charge extends AbstractPersistableCustom<Long> {
         return ChargeTimeType.fromInt(this.chargeTimeType).isOverdueInstallment();
     }
 
+    public boolean isLoanPeriodic() {
+        return ChargeTimeType.fromInt(this.chargeTimeType).isLoanPeriodic();
+    }
+
     public MonthDay getFeeOnMonthDay() {
         MonthDay feeOnMonthDay = null;
         if (this.feeOnDay != null && this.feeOnMonth != null) {
@@ -754,6 +762,21 @@ public class Charge extends AbstractPersistableCustom<Long> {
     public boolean isDisbursementCharge() {
         return ChargeTimeType.fromInt(this.chargeTimeType).equals(ChargeTimeType.DISBURSEMENT)
                 || ChargeTimeType.fromInt(this.chargeTimeType).equals(ChargeTimeType.TRANCHE_DISBURSEMENT);
+    }
+
+    private void validatePeriodicLoanChargeConfiguration(final DataValidatorBuilder baseDataValidator, final ChargeTimeType chargeTime,
+            final MonthDay feeOnMonthDay, final Integer feeInterval, final Integer feeFrequency) {
+        if (!chargeTime.isLoanPeriodic()) {
+            return;
+        }
+
+        baseDataValidator.reset().parameter(FEE_FREQUENCY_PARAM_NAME).value(feeFrequency).notNull().isOneOfTheseValues(
+                PeriodFrequencyType.WEEKS.getValue(), PeriodFrequencyType.MONTHS.getValue(), PeriodFrequencyType.YEARS.getValue());
+        baseDataValidator.reset().parameter(FEE_INTERVAL_PARAM_NAME).value(feeInterval).notNull().integerGreaterThanZero();
+        if (feeOnMonthDay != null) {
+            baseDataValidator.reset().parameter(FEE_ON_MONTH_DAY_PARAM_NAME).value(feeOnMonthDay.toString())
+                    .failWithCode("must.be.blank.for.loan.periodic.charge");
+        }
     }
 
     public TaxGroup getTaxGroup() {

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializer.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializer.java
@@ -43,6 +43,7 @@ import org.apache.fineract.portfolio.charge.domain.ChargeCalculationRegistry;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -185,6 +186,9 @@ public final class ChargeDefinitionCommandFromApiJsonDeserializer {
             if (chargeTimeType != null && chargeCalculationType != null) {
                 performChargeTimeNCalculationTypeValidation(baseDataValidator, chargeTimeType, chargeCalculationType);
             }
+
+            validatePeriodicLoanCharge(baseDataValidator, ChargeTimeType.fromInt(chargeTimeType), feeFrequency, feeInterval,
+                    this.fromApiJsonHelper.extractStringNamed(FEE_ON_MONTH_DAY, element));
 
         } else if (appliesTo.isSavingsCharge()) {
             // savings applicable validation
@@ -480,6 +484,21 @@ public final class ChargeDefinitionCommandFromApiJsonDeserializer {
         } else {
             baseDataValidator.reset().parameter(CHARGE_CALCULATION_TYPE).value(chargeCalculationType)
                     .isNotOneOfTheseValues(ChargeCalculationType.PERCENT_OF_DISBURSEMENT_AMOUNT.getValue());
+        }
+    }
+
+    private void validatePeriodicLoanCharge(final DataValidatorBuilder baseDataValidator, final ChargeTimeType chargeTimeType,
+            final Integer feeFrequency, final Integer feeInterval, final String feeOnMonthDay) {
+        if (!chargeTimeType.isLoanPeriodic()) {
+            return;
+        }
+
+        baseDataValidator.reset().parameter(FEE_FREQUENCY).value(feeFrequency).notNull().isOneOfTheseValues(
+                PeriodFrequencyType.WEEKS.getValue(), PeriodFrequencyType.MONTHS.getValue(), PeriodFrequencyType.YEARS.getValue());
+        baseDataValidator.reset().parameter(FEE_INTERVAL).value(feeInterval).notNull().integerGreaterThanZero();
+        if (StringUtils.isNotBlank(feeOnMonthDay)) {
+            baseDataValidator.reset().parameter(FEE_ON_MONTH_DAY).value(feeOnMonthDay)
+                    .failWithCode("must.be.blank.for.loan.periodic.charge");
         }
     }
 

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeDropdownReadPlatformServiceImpl.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeDropdownReadPlatformServiceImpl.java
@@ -81,7 +81,7 @@ public class ChargeDropdownReadPlatformServiceImpl implements ChargeDropdownRead
     public List<EnumOptionData> retrieveLoanCollectionTimeTypes() {
         return Arrays.asList(chargeTimeType(ChargeTimeType.DISBURSEMENT), chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE),
                 chargeTimeType(ChargeTimeType.INSTALMENT_FEE), chargeTimeType(ChargeTimeType.OVERDUE_INSTALLMENT),
-                chargeTimeType(ChargeTimeType.TRANCHE_DISBURSEMENT));
+                chargeTimeType(ChargeTimeType.TRANCHE_DISBURSEMENT), chargeTimeType(ChargeTimeType.LOAN_PERIODIC));
     }
 
     @Override

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeEnumerations.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeEnumerations.java
@@ -86,8 +86,8 @@ public final class ChargeEnumerations {
                         ChargeTimeType.TRANCHE_DISBURSEMENT.getCode(), "Tranche Disbursement");
             break;
             case LOAN_PERIODIC:
-                optionData = new EnumOptionData(ChargeTimeType.LOAN_PERIODIC.getValue().longValue(),
-                        ChargeTimeType.LOAN_PERIODIC.getCode(), "Periodic Loan Charge");
+                optionData = new EnumOptionData(ChargeTimeType.LOAN_PERIODIC.getValue().longValue(), ChargeTimeType.LOAN_PERIODIC.getCode(),
+                        "Periodic Loan Charge");
             break;
             case SHAREACCOUNT_ACTIVATION:
                 optionData = new EnumOptionData(ChargeTimeType.SHAREACCOUNT_ACTIVATION.getValue().longValue(),

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeEnumerations.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeEnumerations.java
@@ -85,6 +85,10 @@ public final class ChargeEnumerations {
                 optionData = new EnumOptionData(ChargeTimeType.TRANCHE_DISBURSEMENT.getValue().longValue(),
                         ChargeTimeType.TRANCHE_DISBURSEMENT.getCode(), "Tranche Disbursement");
             break;
+            case LOAN_PERIODIC:
+                optionData = new EnumOptionData(ChargeTimeType.LOAN_PERIODIC.getValue().longValue(),
+                        ChargeTimeType.LOAN_PERIODIC.getCode(), "Periodic Loan Charge");
+            break;
             case SHAREACCOUNT_ACTIVATION:
                 optionData = new EnumOptionData(ChargeTimeType.SHAREACCOUNT_ACTIVATION.getValue().longValue(),
                         ChargeTimeType.SHAREACCOUNT_ACTIVATION.getCode(), "Share Account Activate");

--- a/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializerTest.java
+++ b/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializerTest.java
@@ -30,10 +30,10 @@ import org.apache.fineract.portfolio.charge.domain.BasicChargeCalculationDescrip
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.SimpleChargeCalculationRegistry;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.Test;
 
 class ChargeDefinitionCommandFromApiJsonDeserializerTest {
 

--- a/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializerTest.java
+++ b/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializerTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.charge.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.charge.domain.BasicChargeCalculationDescriptor;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.charge.domain.SimpleChargeCalculationRegistry;
+import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
+
+class ChargeDefinitionCommandFromApiJsonDeserializerTest {
+
+    private final ChargeDefinitionCommandFromApiJsonDeserializer underTest = new ChargeDefinitionCommandFromApiJsonDeserializer(
+            new FromJsonHelper(),
+            new SimpleChargeCalculationRegistry(List.of(new BasicChargeCalculationDescriptor(ChargeCalculationType.FLAT.getValue(),
+                    ChargeCalculationType.FLAT.getCode(), "Flat", true, true, true, true, true, true))));
+
+    @ParameterizedTest
+    @MethodSource("validPeriodicFrequencies")
+    void validateForCreateAllowsLoanPeriodicCharge(final PeriodFrequencyType frequencyType) {
+        assertDoesNotThrow(() -> underTest.validateForCreate(periodicLoanChargeJson(frequencyType.getValue(), 1, null)));
+    }
+
+    @Test
+    void validateForCreateRejectsLoanPeriodicChargeWithoutFeeFrequency() {
+        final PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.validateForCreate(periodicLoanChargeJson(null, 1, null)));
+
+        assertThat(exception.getErrors()).extracting("parameterName").contains("feeFrequency");
+    }
+
+    @Test
+    void validateForCreateRejectsLoanPeriodicChargeWithUnsupportedFeeFrequency() {
+        final PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.validateForCreate(periodicLoanChargeJson(PeriodFrequencyType.DAYS.getValue(), 1, null)));
+
+        assertThat(exception.getErrors()).extracting("parameterName").contains("feeFrequency");
+    }
+
+    @Test
+    void validateForCreateRejectsLoanPeriodicChargeWithFeeOnMonthDay() {
+        final PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.validateForCreate(periodicLoanChargeJson(PeriodFrequencyType.YEARS.getValue(), 1, "04 March")));
+
+        assertThat(exception.getErrors()).extracting("parameterName").contains("feeOnMonthDay");
+    }
+
+    private static Stream<Arguments> validPeriodicFrequencies() {
+        return Stream.of(Arguments.of(PeriodFrequencyType.WEEKS), Arguments.of(PeriodFrequencyType.MONTHS),
+                Arguments.of(PeriodFrequencyType.YEARS));
+    }
+
+    private String periodicLoanChargeJson(final Integer feeFrequency, final Integer feeInterval, final String feeOnMonthDay) {
+        final String feeFrequencyJson = feeFrequency == null ? "null" : feeFrequency.toString();
+        final String feeOnMonthDayJson = feeOnMonthDay == null ? "null" : "\"" + feeOnMonthDay + "\"";
+        return """
+                {
+                  "name": "Periodic Insurance",
+                  "amount": 10,
+                  "locale": "en",
+                  "currencyCode": "USD",
+                  "chargeAppliesTo": 1,
+                  "chargeCalculationType": 1,
+                  "chargeTimeType": 17,
+                  "chargePaymentMode": 0,
+                  "penalty": false,
+                  "active": true,
+                  "monthDayFormat": "dd MMM",
+                  "feeFrequency": %s,
+                  "feeInterval": %d,
+                  "feeOnMonthDay": %s
+                }
+                """.formatted(feeFrequencyJson, feeInterval, feeOnMonthDayJson);
+    }
+}

--- a/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializerTest.java
+++ b/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/serialization/ChargeDefinitionCommandFromApiJsonDeserializerTest.java
@@ -80,23 +80,10 @@ class ChargeDefinitionCommandFromApiJsonDeserializerTest {
     private String periodicLoanChargeJson(final Integer feeFrequency, final Integer feeInterval, final String feeOnMonthDay) {
         final String feeFrequencyJson = feeFrequency == null ? "null" : feeFrequency.toString();
         final String feeOnMonthDayJson = feeOnMonthDay == null ? "null" : "\"" + feeOnMonthDay + "\"";
-        return """
-                {
-                  "name": "Periodic Insurance",
-                  "amount": 10,
-                  "locale": "en",
-                  "currencyCode": "USD",
-                  "chargeAppliesTo": 1,
-                  "chargeCalculationType": 1,
-                  "chargeTimeType": 17,
-                  "chargePaymentMode": 0,
-                  "penalty": false,
-                  "active": true,
-                  "monthDayFormat": "dd MMM",
-                  "feeFrequency": %s,
-                  "feeInterval": %d,
-                  "feeOnMonthDay": %s
-                }
-                """.formatted(feeFrequencyJson, feeInterval, feeOnMonthDayJson);
+        return String.join(System.lineSeparator(), "{", "  \"name\": \"Periodic Insurance\",", "  \"amount\": 10,", "  \"locale\": \"en\",",
+                "  \"currencyCode\": \"USD\",", "  \"chargeAppliesTo\": 1,", "  \"chargeCalculationType\": 1,", "  \"chargeTimeType\": 17,",
+                "  \"chargePaymentMode\": 0,", "  \"penalty\": false,", "  \"active\": true,", "  \"monthDayFormat\": \"dd MMM\",",
+                "  \"feeFrequency\": " + feeFrequencyJson + ",", "  \"feeInterval\": " + feeInterval + ",",
+                "  \"feeOnMonthDay\": " + feeOnMonthDayJson, "}");
     }
 }

--- a/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/service/ChargeDropdownReadPlatformServiceImplTest.java
+++ b/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/service/ChargeDropdownReadPlatformServiceImplTest.java
@@ -34,9 +34,9 @@ class ChargeDropdownReadPlatformServiceImplTest {
         ChargeDropdownReadPlatformServiceImpl underTest = new ChargeDropdownReadPlatformServiceImpl(
                 new SimpleChargeCalculationRegistry(List.of(new BasicChargeCalculationDescriptor(ChargeCalculationType.FLAT.getValue(),
                         ChargeCalculationType.FLAT.getCode(), "Flat", true, true, true, true, true, true))),
-                new ChargeCalculationOptionDataService(new SimpleChargeCalculationRegistry(List.of(new BasicChargeCalculationDescriptor(
-                        ChargeCalculationType.FLAT.getValue(), ChargeCalculationType.FLAT.getCode(), "Flat", true, true, true, true,
-                        true, true)))));
+                new ChargeCalculationOptionDataService(new SimpleChargeCalculationRegistry(
+                        List.of(new BasicChargeCalculationDescriptor(ChargeCalculationType.FLAT.getValue(),
+                                ChargeCalculationType.FLAT.getCode(), "Flat", true, true, true, true, true, true)))));
 
         assertThat(underTest.retrieveLoanCollectionTimeTypes()).extracting("id")
                 .contains(Long.valueOf(ChargeTimeType.LOAN_PERIODIC.getValue()));

--- a/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/service/ChargeDropdownReadPlatformServiceImplTest.java
+++ b/fineract-charge/src/test/java/org/apache/fineract/portfolio/charge/service/ChargeDropdownReadPlatformServiceImplTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.charge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.fineract.portfolio.charge.domain.BasicChargeCalculationDescriptor;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.charge.domain.SimpleChargeCalculationRegistry;
+import org.junit.jupiter.api.Test;
+
+class ChargeDropdownReadPlatformServiceImplTest {
+
+    @Test
+    void retrieveLoanCollectionTimeTypesIncludesPeriodicLoanCharge() {
+        ChargeDropdownReadPlatformServiceImpl underTest = new ChargeDropdownReadPlatformServiceImpl(
+                new SimpleChargeCalculationRegistry(List.of(new BasicChargeCalculationDescriptor(ChargeCalculationType.FLAT.getValue(),
+                        ChargeCalculationType.FLAT.getCode(), "Flat", true, true, true, true, true, true))),
+                new ChargeCalculationOptionDataService(new SimpleChargeCalculationRegistry(List.of(new BasicChargeCalculationDescriptor(
+                        ChargeCalculationType.FLAT.getValue(), ChargeCalculationType.FLAT.getCode(), "Flat", true, true, true, true,
+                        true, true)))));
+
+        assertThat(underTest.retrieveLoanCollectionTimeTypes()).extracting("id")
+                .contains(Long.valueOf(ChargeTimeType.LOAN_PERIODIC.getValue()));
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/charge/domain/ChargeTimeType.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/charge/domain/ChargeTimeType.java
@@ -36,7 +36,8 @@ public enum ChargeTimeType {
     SHAREACCOUNT_ACTIVATION(13, "chargeTimeType.activation"), // only for shares
     SHARE_PURCHASE(14, "chargeTimeType.sharespurchase"), // only for shares
     SHARE_REDEEM(15, "chargeTimeType.sharesredeem"), // only for shares
-    SAVINGS_NOACTIVITY_FEE(16, "chargeTimeType.savingsNoActivityFee"); // only for savings
+    SAVINGS_NOACTIVITY_FEE(16, "chargeTimeType.savingsNoActivityFee"), // only for savings
+    LOAN_PERIODIC(17, "chargeTimeType.loanPeriodic"); // only for loans
 
     private final Integer value;
     private final String code;
@@ -57,7 +58,7 @@ public enum ChargeTimeType {
     public static Object[] validLoanValues() {
         return new Integer[] { ChargeTimeType.DISBURSEMENT.getValue(), ChargeTimeType.SPECIFIED_DUE_DATE.getValue(),
                 ChargeTimeType.INSTALMENT_FEE.getValue(), ChargeTimeType.OVERDUE_INSTALLMENT.getValue(),
-                ChargeTimeType.TRANCHE_DISBURSEMENT.getValue() };
+                ChargeTimeType.TRANCHE_DISBURSEMENT.getValue(), ChargeTimeType.LOAN_PERIODIC.getValue() };
     }
 
     public static Object[] validLoanChargeValues() {
@@ -133,6 +134,9 @@ public enum ChargeTimeType {
                 case 16:
                     chargeTimeType = SAVINGS_NOACTIVITY_FEE;
                 break;
+                case 17:
+                    chargeTimeType = LOAN_PERIODIC;
+                break;
                 default:
                     chargeTimeType = INVALID;
                 break;
@@ -190,7 +194,8 @@ public enum ChargeTimeType {
     }
 
     public boolean isAllowedLoanChargeTime() {
-        return isTimeOfDisbursement() || isOnSpecifiedDueDate() || isInstalmentFee() || isOverdueInstallment() || isTrancheDisbursement();
+        return isTimeOfDisbursement() || isOnSpecifiedDueDate() || isInstalmentFee() || isOverdueInstallment() || isTrancheDisbursement()
+                || isLoanPeriodic();
     }
 
     public boolean isAllowedClientChargeTime() {
@@ -208,6 +213,10 @@ public enum ChargeTimeType {
 
     public boolean isTrancheDisbursement() {
         return this.equals(ChargeTimeType.TRANCHE_DISBURSEMENT);
+    }
+
+    public boolean isLoanPeriodic() {
+        return this.equals(ChargeTimeType.LOAN_PERIODIC);
     }
 
     public boolean isShareAccountActivation() {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/Loan.java
@@ -1263,7 +1263,7 @@ public class Loan extends AbstractAuditableWithUTCDateTimeCustom<Long> {
         final BiFunction<LocalDate, LocalDate, LocalDate> earlierDate = (date1, date2) -> DateUtils.isBefore(date1, date2) ? date1 : date2;
 
         return this.charges.stream().filter(LoanCharge::isActive)
-                .filter(loanCharge -> loanCharge.isSpecifiedDueDate() || loanCharge.isOverdueInstallmentCharge())
+                .filter(loanCharge -> loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic() || loanCharge.isOverdueInstallmentCharge())
                 .filter(loanCharge -> loanCharge.getDueLocalDate() != null).anyMatch(loanCharge -> {
                     final LocalDate comparisonDate = earlierDate.apply(loanCharge.getDueLocalDate(), loanCharge.getSubmittedOnDate());
                     return comparisonDate != null && comparisonDate.isAfter(transaction.getTransactionDate());

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCharge.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCharge.java
@@ -239,6 +239,10 @@ public class LoanCharge extends AbstractAuditableWithUTCDateTimeCustom<Long> {
         return ChargeTimeType.fromInt(this.chargeTime).equals(ChargeTimeType.SPECIFIED_DUE_DATE);
     }
 
+    public boolean isPeriodic() {
+        return ChargeTimeType.fromInt(this.chargeTime).equals(ChargeTimeType.LOAN_PERIODIC);
+    }
+
     public boolean isInstalmentFee() {
         return ChargeTimeType.fromInt(this.chargeTime).equals(ChargeTimeType.INSTALMENT_FEE);
     }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleProcessingWrapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleProcessingWrapper.java
@@ -104,7 +104,7 @@ public class LoanRepaymentScheduleProcessingWrapper {
                         // multi disburment loan.
                         // Then we need to get as of this loan charge due date
                         // how much amount disbursed.
-                        if (loanCharge.getLoan() != null && loanCharge.isSpecifiedDueDate()
+                        if (loanCharge.getLoan() != null && (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic())
                                 && loanCharge.getLoan().isMultiDisburmentLoan()) {
                             for (final LoanDisbursementDetails loanDisbursementDetails : loanCharge.getLoan().getDisbursementDetails()) {
                                 if (!DateUtils.isAfter(loanDisbursementDetails.expectedDisbursementDate(), loanCharge.getDueDate())) {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapper.java
@@ -127,8 +127,7 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapper {
         BigDecimal baseAmount = BigDecimal.ZERO;
         Loan loan = loanCharge.getLoan();
         if (loan != null && loanCharge.isFeeCharge() && !calculationType.hasInterest()
-                && (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic())
-                && loan.isMultiDisburmentLoan()) {
+                && (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic()) && loan.isMultiDisburmentLoan()) {
             // If charge type is specified due date and loan is multi disburment loan.
             // Then we need to get as of this loan charge due date how much amount disbursed.
             for (final LoanDisbursementDetails loanDisbursementDetails : loan.getDisbursementDetails()) {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapper.java
@@ -45,7 +45,7 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapper {
             totalPrincipal = totalPrincipal.plus(installment.getPrincipal(currency));
         }
         List<LoanChargePaidBy> accruals = null;
-        if (loanCharge.isSpecifiedDueDate()) {
+        if (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic()) {
             LoanRepaymentScheduleInstallment addedPeriod = addChargeOnlyRepaymentInstallmentIfRequired(loanCharge, installments);
             if (addedPeriod != null) {
                 addedPeriod.updateObligationsMet(currency, disbursementDate);
@@ -126,7 +126,8 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapper {
         }
         BigDecimal baseAmount = BigDecimal.ZERO;
         Loan loan = loanCharge.getLoan();
-        if (loan != null && loanCharge.isFeeCharge() && !calculationType.hasInterest() && loanCharge.isSpecifiedDueDate()
+        if (loan != null && loanCharge.isFeeCharge() && !calculationType.hasInterest()
+                && (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic())
                 && loan.isMultiDisburmentLoan()) {
             // If charge type is specified due date and loan is multi disburment loan.
             // Then we need to get as of this loan charge due date how much amount disbursed.
@@ -211,7 +212,7 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapper {
         if (installments == null) {
             return null;
         }
-        if (!loanCharge.isSpecifiedDueDate()) {
+        if (!(loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic())) {
             return null;
         }
         LocalDate chargeDueDate = loanCharge.getEffectiveDueDate();

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractCumulativeLoanScheduleGenerator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/loanschedule/domain/AbstractCumulativeLoanScheduleGenerator.java
@@ -2064,7 +2064,7 @@ public abstract class AbstractCumulativeLoanScheduleGenerator implements LoanSch
     private Set<LoanCharge> separateTotalCompoundingPercentageCharges(final Set<LoanCharge> loanCharges) {
         Set<LoanCharge> interestCharges = new HashSet<>();
         for (final LoanCharge loanCharge : loanCharges) {
-            if (loanCharge.isSpecifiedDueDate() && (loanCharge.getChargeCalculation().isPercentageOfInterest()
+            if ((loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic()) && (loanCharge.getChargeCalculation().isPercentageOfInterest()
                     || loanCharge.getChargeCalculation().isPercentageOfAmountAndInterest())) {
                 interestCharges.add(loanCharge);
             }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanChargeApiJsonValidator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanChargeApiJsonValidator.java
@@ -90,6 +90,13 @@ public final class LoanChargeApiJsonValidator {
         final JsonElement element = this.fromApiJsonHelper.parse(json);
         final Long chargeId = this.fromApiJsonHelper.extractLongNamed("chargeId", element);
         baseDataValidator.reset().parameter("chargeId").value(chargeId).notNull().integerGreaterThanZero();
+        if (chargeId != null) {
+            final Charge chargeDefinition = chargeRepository.findOneWithNotFoundDetection(chargeId);
+            if (chargeDefinition.isLoanPeriodic()) {
+                throw new LoanChargeCannotBeAddedException("loanCharge", "periodic.charge",
+                        "Periodic charge cannot be added to the loan manually.", null, chargeDefinition.getName());
+            }
+        }
 
         final BigDecimal amount = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed("amount", element);
         baseDataValidator.reset().parameter("amount").value(amount).notNull().positiveAmount();
@@ -362,6 +369,10 @@ public final class LoanChargeApiJsonValidator {
                         final String defaultUserMessage = "Installment charge cannot be added to the loan.";
                         throw new LoanChargeCannotBeAddedException("loanCharge", "overdue.charge", defaultUserMessage, null,
                                 chargeDefinition.getName());
+                    }
+                    if (chargeDefinition.isLoanPeriodic()) {
+                        throw new LoanChargeCannotBeAddedException("loanCharge", "periodic.charge",
+                                "Periodic charge cannot be added to the loan manually.", null, chargeDefinition.getName());
                     }
                     final BigDecimal amount = this.fromApiJsonHelper.extractBigDecimalNamed(LoanApiConstants.amountParameterName,
                             loanChargeElement, locale);

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanChargeValidator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanChargeValidator.java
@@ -58,7 +58,8 @@ public final class LoanChargeValidator {
 
     public void validateChargeHasValidSpecifiedDateIfApplicable(final Loan loan, final LoanCharge loanCharge,
             final LocalDate disbursementDate) {
-        if (loanCharge.isSpecifiedDueDate() && DateUtils.isBefore(loanCharge.getDueLocalDate(), disbursementDate)) {
+        if ((loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic())
+                && DateUtils.isBefore(loanCharge.getDueLocalDate(), disbursementDate)) {
             final String defaultUserMessage = "This charge with specified due date cannot be added as the it is not in schedule range.";
             throw new LoanChargeCannotBeAddedException("loanCharge", "specified.due.date.outside.range", defaultUserMessage,
                     loan.getDisbursementDate(), loanCharge.name());

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/PercentOfAmountAndInterestChargeCalculationValidator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/PercentOfAmountAndInterestChargeCalculationValidator.java
@@ -38,7 +38,7 @@ public class PercentOfAmountAndInterestChargeCalculationValidator implements Cha
         if (loanCharge.isInstalmentFee()) {
             return "installment." + LoanApiConstants.LOAN_CHARGE_CAN_NOT_BE_ADDED_WITH_PRINCIPAL_CALCULATION_TYPE;
         }
-        if (loanCharge.isSpecifiedDueDate()) {
+        if (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic()) {
             return "specific." + LoanApiConstants.LOAN_CHARGE_CAN_NOT_BE_ADDED_WITH_INTEREST_CALCULATION_TYPE;
         }
         return null;
@@ -49,7 +49,7 @@ public class PercentOfAmountAndInterestChargeCalculationValidator implements Cha
         if (chargeTime.isInstalmentFee()) {
             return "installment." + LoanApiConstants.LOAN_CHARGE_CAN_NOT_BE_ADDED_WITH_PRINCIPAL_CALCULATION_TYPE;
         }
-        if (chargeTime.isSpecifiedDueDate()) {
+        if (chargeTime.isSpecifiedDueDate() || chargeTime.isLoanPeriodic()) {
             return "specific." + LoanApiConstants.LOAN_CHARGE_CAN_NOT_BE_ADDED_WITH_INTEREST_CALCULATION_TYPE;
         }
         return null;

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/PercentOfInterestChargeCalculationValidator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/PercentOfInterestChargeCalculationValidator.java
@@ -37,7 +37,7 @@ public class PercentOfInterestChargeCalculationValidator implements ChargeCalcul
 
     @Override
     public String validateLoanCharge(LoanCharge loanCharge) {
-        if (loanCharge.isSpecifiedDueDate()) {
+        if (loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic()) {
             return "specific." + LoanApiConstants.LOAN_CHARGE_CAN_NOT_BE_ADDED_WITH_INTEREST_CALCULATION_TYPE;
         }
         if (loanCharge.isInstalmentFee() && loanCharge.getLoan().isProgressiveSchedule()) {
@@ -48,7 +48,7 @@ public class PercentOfInterestChargeCalculationValidator implements ChargeCalcul
 
     @Override
     public String validateLoanProductRestriction(ChargeTimeType chargeTime, LoanProduct loanProduct) {
-        if (chargeTime.isSpecifiedDueDate()) {
+        if (chargeTime.isSpecifiedDueDate() || chargeTime.isLoanPeriodic()) {
             return "specific." + LoanApiConstants.LOAN_CHARGE_CAN_NOT_BE_ADDED_WITH_INTEREST_CALCULATION_TYPE;
         }
         LoanProductRelatedDetail detail = loanProduct.getLoanProductRelatedDetail();

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeService.java
@@ -435,7 +435,8 @@ public class LoanChargeService {
         loanCharge.setChargeTime(chargeTime == null ? chargeDefinition.getChargeTimeType() : chargeTime.getValue());
 
         if (loanCharge.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE)
-                || loanCharge.getChargeTimeType().equals(ChargeTimeType.OVERDUE_INSTALLMENT)) {
+                || loanCharge.getChargeTimeType().equals(ChargeTimeType.OVERDUE_INSTALLMENT)
+                || loanCharge.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC)) {
 
             if (dueDate == null) {
                 final String defaultUserMessage = "Loan charge is missing due date.";

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformService.java
@@ -44,4 +44,6 @@ public interface LoanChargeWritePlatformService {
     CommandProcessingResult deactivateOverdueLoanCharge(Long loanId, JsonCommand command);
 
     void applyOverdueChargesForLoan(Long loanId, Collection<OverdueLoanScheduleData> overdueLoanScheduleDataList);
+
+    void applyPeriodicChargesForLoan(Long loanId);
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/PercentOfAmountChargeAmountCalculator.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/PercentOfAmountChargeAmountCalculator.java
@@ -50,7 +50,7 @@ public class PercentOfAmountChargeAmountCalculator implements ChargeAmountCalcul
         BigDecimal amount = BigDecimal.ZERO;
         if (loan.isMultiDisburmentLoan() && loanCharge.getCharge().getChargeTimeType().equals(ChargeTimeType.DISBURSEMENT.getValue())) {
             amount = loan.getApprovedPrincipal();
-        } else if (loanCharge.isSpecifiedDueDate() && loan.isMultiDisburmentLoan()) {
+        } else if ((loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic()) && loan.isMultiDisburmentLoan()) {
             for (final LoanDisbursementDetails loanDisbursementDetails : loan.getDisbursementDetails()) {
                 if (!DateUtils.isAfter(loanDisbursementDetails.expectedDisbursementDate(), loanCharge.getDueDate())) {
                     amount = amount.add(loanDisbursementDetails.principal());

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapperTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapperTest.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.portfolio.loanaccount.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -128,6 +130,30 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapperTest {
         customVerify(period2, "0.0", "0.0", "0.0", "0.0", "0.0", "0.0");
     }
 
+    @Test
+    public void testPeriodicChargeAfterMaturityAddsAdditionalInstallment() {
+        LocalDate disbursementDate = LocalDate.of(2023, 1, 1);
+        ThreadLocalContextUtil
+                .setBusinessDates(new HashMap<>(new EnumMap<>(Map.of(BusinessDateType.BUSINESS_DATE, disbursementDate))));
+        Loan loan = mock(Loan.class);
+        when(loan.isInterestBearing()).thenReturn(false);
+        when(loan.getLoanRepaymentScheduleInstallmentsSize()).thenReturn(1);
+
+        LoanRepaymentScheduleInstallment existingInstallment = createPeriod(1, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31));
+        List<LoanRepaymentScheduleInstallment> installments = new ArrayList<>(List.of(existingInstallment));
+
+        LoanCharge periodicCharge = createCharge(loan, ChargeTimeType.LOAN_PERIODIC, LocalDate.of(2023, 2, 15), false);
+
+        LoanRepaymentScheduleInstallment additionalInstallment = underTest.addChargeOnlyRepaymentInstallmentIfRequired(periodicCharge,
+                installments);
+
+        assertNotNull(additionalInstallment);
+        assertEquals(LocalDate.of(2023, 2, 15), additionalInstallment.getDueDate());
+        assertEquals(LocalDate.of(2023, 1, 31), additionalInstallment.getFromDate());
+        assertEquals(true, additionalInstallment.isAdditional());
+        verify(loan, times(1)).addLoanRepaymentScheduleInstallment(additionalInstallment);
+    }
+
     private void customVerify(LoanRepaymentScheduleInstallment period, String expectedFeeChargesDue, String expectedFeeChargesWaived,
             String expectedFeeChargesWrittenOff, String expectedPenaltyChargesDue, String expectedPenaltyChargesWaived,
             String expectedPenaltyChargesWrittenOff) {
@@ -151,16 +177,21 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapperTest {
 
     @NonNull
     private LoanCharge createCharge(boolean penalty) {
+        Loan loan = mock(Loan.class);
+        when(loan.isInterestBearing()).thenReturn(false);
+        return createCharge(loan, ChargeTimeType.SPECIFIED_DUE_DATE, LocalDate.of(2023, 1, 15), penalty);
+    }
+
+    @NonNull
+    private LoanCharge createCharge(Loan loan, ChargeTimeType chargeTimeType, LocalDate dueDate, boolean penalty) {
         Charge charge = mock(Charge.class);
         when(charge.getId()).thenReturn(1L);
         when(charge.getName()).thenReturn("charge a");
         when(charge.getCurrencyCode()).thenReturn("UDS");
         when(charge.isPenalty()).thenReturn(penalty);
-        Loan loan = mock(Loan.class);
-        when(loan.isInterestBearing()).thenReturn(false);
 
-        return loanChargeService.create(loan, charge, new BigDecimal(1000), new BigDecimal(10), ChargeTimeType.SPECIFIED_DUE_DATE,
-                ChargeCalculationType.FLAT, LocalDate.of(2023, 1, 15), ChargePaymentMode.REGULAR, 1, null, null);
+        return loanChargeService.create(loan, charge, new BigDecimal(1000), new BigDecimal(10), chargeTimeType, ChargeCalculationType.FLAT,
+                dueDate, ChargePaymentMode.REGULAR, 1, null, null);
     }
 
     @NonNull

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapperTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/SingleLoanChargeRepaymentScheduleProcessingWrapperTest.java
@@ -133,8 +133,7 @@ public class SingleLoanChargeRepaymentScheduleProcessingWrapperTest {
     @Test
     public void testPeriodicChargeAfterMaturityAddsAdditionalInstallment() {
         LocalDate disbursementDate = LocalDate.of(2023, 1, 1);
-        ThreadLocalContextUtil
-                .setBusinessDates(new HashMap<>(new EnumMap<>(Map.of(BusinessDateType.BUSINESS_DATE, disbursementDate))));
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(new EnumMap<>(Map.of(BusinessDateType.BUSINESS_DATE, disbursementDate))));
         Loan loan = mock(Loan.class);
         when(loan.isInterestBearing()).thenReturn(false);
         when(loan.getLoanRepaymentScheduleInstallmentsSize()).thenReturn(1);

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanChargeApiJsonValidatorTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanChargeApiJsonValidatorTest.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.serialization;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonElement;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepositoryWrapper;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.charge.exception.LoanChargeCannotBeAddedException;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanChargeRepository;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LoanChargeApiJsonValidatorTest {
+
+    private static final Long CHARGE_ID = 1L;
+
+    @Mock
+    private ChargeRepositoryWrapper chargeRepository;
+
+    @Mock
+    private LoanChargeRepository loanChargeRepository;
+
+    @Mock
+    private Charge charge;
+
+    @Mock
+    private LoanProduct loanProduct;
+
+    private FromJsonHelper fromJsonHelper;
+    private LoanChargeApiJsonValidator underTest;
+
+    @BeforeEach
+    void setUp() {
+        fromJsonHelper = new FromJsonHelper();
+        underTest = new LoanChargeApiJsonValidator(fromJsonHelper, chargeRepository, loanChargeRepository, List.of());
+
+        when(chargeRepository.findOneWithNotFoundDetection(CHARGE_ID)).thenReturn(charge);
+    }
+
+    @Test
+    void validateAddLoanChargeRejectsPeriodicCharges() {
+        when(charge.isLoanPeriodic()).thenReturn(true);
+
+        assertThatThrownBy(() -> underTest.validateAddLoanCharge("""
+                {
+                  "chargeId": 1,
+                  "amount": 100,
+                  "locale": "en"
+                }
+                """)).isInstanceOf(LoanChargeCannotBeAddedException.class)
+                .hasMessageContaining("Periodic charge cannot be added to the loan manually.");
+    }
+
+    @Test
+    void validateLoanChargesRejectsPeriodicChargesInLoanPayload() {
+        when(charge.isLoanPeriodic()).thenReturn(true);
+        when(charge.getCurrencyCode()).thenReturn("USD");
+        when(charge.getChargeTimeType()).thenReturn(ChargeTimeType.LOAN_PERIODIC.getValue());
+        when(charge.getChargeCalculation()).thenReturn(ChargeCalculationType.FLAT.getValue());
+        when(charge.getChargePaymentMode()).thenReturn(ChargePaymentMode.REGULAR.getValue());
+        when(loanProduct.hasCurrencyCodeOf("USD")).thenReturn(true);
+
+        JsonElement element = fromJsonHelper.parse("""
+                {
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "expectedDisbursementDate": "01 January 2024",
+                  "charges": [
+                    {
+                      "chargeId": 1,
+                      "amount": 100,
+                      "dueDate": "15 January 2024"
+                    }
+                  ]
+                }
+                """);
+        DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(new ArrayList<ApiParameterError>()).resource("loan");
+
+        assertThatThrownBy(() -> underTest.validateLoanCharges(element, loanProduct, baseDataValidator))
+                .isInstanceOf(LoanChargeCannotBeAddedException.class)
+                .hasMessageContaining("Periodic charge cannot be added to the loan manually.");
+    }
+
+    @Test
+    void validateAddLoanChargeAllowsNonPeriodicCharges() {
+        when(charge.isLoanPeriodic()).thenReturn(false);
+
+        assertDoesNotThrow(() -> underTest.validateAddLoanCharge("""
+                {
+                  "chargeId": 1,
+                  "amount": 100,
+                  "locale": "en"
+                }
+                """));
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResource.java
@@ -542,7 +542,7 @@ public class LoanChargesApiResource {
         Long resolvedLoanId = loanId == null ? loanReadPlatformService.getResolvedLoanId(loanExternalId) : loanId;
 
         final List<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveLoanAccountApplicableCharges(resolvedLoanId,
-                new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT });
+                new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.LOAN_PERIODIC });
         final LoanChargeData loanChargeTemplate = LoanChargeData.template(chargeOptions);
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -1203,9 +1203,8 @@ public class LoansApiResource {
                 chargeOptions = this.chargeReadPlatformService.retrieveLoanAccountApplicableCharges(resolvedLoanId,
                         new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.LOAN_PERIODIC });
             } else {
-                chargeOptions = this.chargeReadPlatformService.retrieveLoanAccountApplicableCharges(resolvedLoanId,
-                        new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT,
-                                ChargeTimeType.LOAN_PERIODIC });
+                chargeOptions = this.chargeReadPlatformService.retrieveLoanAccountApplicableCharges(resolvedLoanId, new ChargeTimeType[] {
+                        ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT, ChargeTimeType.LOAN_PERIODIC });
             }
             chargeTemplate = this.loanChargeReadPlatformService.retrieveLoanChargeTemplate();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -1201,10 +1201,11 @@ public class LoansApiResource {
             repaymentStrategyOptions = this.dropdownReadPlatformService.retrieveTransactionProcessingStrategies();
             if (product.getMultiDisburseLoan()) {
                 chargeOptions = this.chargeReadPlatformService.retrieveLoanAccountApplicableCharges(resolvedLoanId,
-                        new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT });
+                        new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.LOAN_PERIODIC });
             } else {
                 chargeOptions = this.chargeReadPlatformService.retrieveLoanAccountApplicableCharges(resolvedLoanId,
-                        new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT });
+                        new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT,
+                                ChargeTimeType.LOAN_PERIODIC });
             }
             chargeTemplate = this.loanChargeReadPlatformService.retrieveLoanChargeTemplate();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAssemblerImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAssemblerImpl.java
@@ -497,7 +497,8 @@ public class LoanAssemblerImpl implements LoanAssembler {
             } else {
                 LoanChargeData chargeData = chargesMap.get(loanCharge.getId());
                 if (loanCharge.amountOrPercentage().compareTo(chargeData.getAmountOrPercentage()) != 0
-                        || (loanCharge.isSpecifiedDueDate() && !loanCharge.getDueLocalDate().equals(chargeData.getDueDate()))) {
+                        || ((loanCharge.isSpecifiedDueDate() || loanCharge.isPeriodic())
+                                && !loanCharge.getDueLocalDate().equals(chargeData.getDueDate()))) {
                     isChargeModified = true;
                 }
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeAssembler.java
@@ -290,8 +290,7 @@ public class LoanChargeAssembler {
         // Then we need to get as of this loan charge due date how much amount
         // disbursed.
         if ((chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
-                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue()))
-                && loan.isMultiDisburmentLoan()) {
+                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue())) && loan.isMultiDisburmentLoan()) {
             amountPercentageAppliedTo = BigDecimal.ZERO;
             for (final LoanDisbursementDetails loanDisbursementDetails : loan.getDisbursementDetails()) {
                 if (!DateUtils.isAfter(loanDisbursementDetails.expectedDisbursementDate(), dueDate)) {
@@ -325,16 +324,14 @@ public class LoanChargeAssembler {
 
         final JsonCommand emptyCommand = JsonCommand.fromJsonElement(null, new JsonObject(), fromApiJsonHelper);
         BigDecimal amountPercentageAppliedTo = chargeAmountCalculatorRegistry.find(chargeDefinition.getChargeCalculation())
-                .map(calculator -> calculator.calculateCreationAmountPercentageAppliedTo(loan, emptyCommand, null))
-                .orElse(BigDecimal.ZERO);
+                .map(calculator -> calculator.calculateCreationAmountPercentageAppliedTo(loan, emptyCommand, null)).orElse(BigDecimal.ZERO);
         BigDecimal loanCharge = BigDecimal.ZERO;
         if (ChargeTimeType.fromInt(chargeDefinition.getChargeTimeType()).equals(ChargeTimeType.INSTALMENT_FEE)) {
             loanCharge = loanChargeService.calculatePerInstallmentChargeAmount(loan,
                     ChargeCalculationType.fromInt(chargeDefinition.getChargeCalculation()), chargeDefinition.getAmount());
         }
         if ((chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
-                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue()))
-                && loan.isMultiDisburmentLoan()) {
+                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue())) && loan.isMultiDisburmentLoan()) {
             amountPercentageAppliedTo = BigDecimal.ZERO;
             for (final LoanDisbursementDetails loanDisbursementDetails : loan.getDisbursementDetails()) {
                 if (!DateUtils.isAfter(loanDisbursementDetails.expectedDisbursementDate(), dueDate)) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeAssembler.java
@@ -249,7 +249,8 @@ public class LoanChargeAssembler {
 
     public LoanCharge createNewFromJson(final Loan loan, final Charge chargeDefinition, final JsonCommand command) {
         final LocalDate dueDate = command.localDateValueOfParameterNamed("dueDate");
-        if (chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()) && dueDate == null) {
+        if ((chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
+                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue())) && dueDate == null) {
             final String defaultUserMessage = "Loan charge is missing due date.";
             throw new LoanChargeWithoutMandatoryFieldException("loanCharge", "dueDate", defaultUserMessage, chargeDefinition.getId(),
                     chargeDefinition.getName());
@@ -288,7 +289,9 @@ public class LoanChargeAssembler {
         // loan.
         // Then we need to get as of this loan charge due date how much amount
         // disbursed.
-        if (chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()) && loan.isMultiDisburmentLoan()) {
+        if ((chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
+                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue()))
+                && loan.isMultiDisburmentLoan()) {
             amountPercentageAppliedTo = BigDecimal.ZERO;
             for (final LoanDisbursementDetails loanDisbursementDetails : loan.getDisbursementDetails()) {
                 if (!DateUtils.isAfter(loanDisbursementDetails.expectedDisbursementDate(), dueDate)) {
@@ -310,5 +313,36 @@ public class LoanChargeAssembler {
             final ChargePaymentMode chargePaymentMode, final Integer numberOfRepayments, final ExternalId externalId) {
         return loanChargeService.create(null, chargeDefinition, loanPrincipal, amount, chargeTime, chargeCalculation, dueDate,
                 chargePaymentMode, numberOfRepayments, BigDecimal.ZERO, externalId);
+    }
+
+    public LoanCharge createNewFromChargeDefinition(final Loan loan, final Charge chargeDefinition, final LocalDate dueDate) {
+        if ((chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
+                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue())) && dueDate == null) {
+            final String defaultUserMessage = "Loan charge is missing due date.";
+            throw new LoanChargeWithoutMandatoryFieldException("loanCharge", "dueDate", defaultUserMessage, chargeDefinition.getId(),
+                    chargeDefinition.getName());
+        }
+
+        final JsonCommand emptyCommand = JsonCommand.fromJsonElement(null, new JsonObject(), fromApiJsonHelper);
+        BigDecimal amountPercentageAppliedTo = chargeAmountCalculatorRegistry.find(chargeDefinition.getChargeCalculation())
+                .map(calculator -> calculator.calculateCreationAmountPercentageAppliedTo(loan, emptyCommand, null))
+                .orElse(BigDecimal.ZERO);
+        BigDecimal loanCharge = BigDecimal.ZERO;
+        if (ChargeTimeType.fromInt(chargeDefinition.getChargeTimeType()).equals(ChargeTimeType.INSTALMENT_FEE)) {
+            loanCharge = loanChargeService.calculatePerInstallmentChargeAmount(loan,
+                    ChargeCalculationType.fromInt(chargeDefinition.getChargeCalculation()), chargeDefinition.getAmount());
+        }
+        if ((chargeDefinition.getChargeTimeType().equals(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
+                || chargeDefinition.getChargeTimeType().equals(ChargeTimeType.LOAN_PERIODIC.getValue()))
+                && loan.isMultiDisburmentLoan()) {
+            amountPercentageAppliedTo = BigDecimal.ZERO;
+            for (final LoanDisbursementDetails loanDisbursementDetails : loan.getDisbursementDetails()) {
+                if (!DateUtils.isAfter(loanDisbursementDetails.expectedDisbursementDate(), dueDate)) {
+                    amountPercentageAppliedTo = amountPercentageAppliedTo.add(loanDisbursementDetails.principal());
+                }
+            }
+        }
+        return loanChargeService.create(loan, chargeDefinition, amountPercentageAppliedTo, null, null, null, dueDate, null, null,
+                loanCharge, externalIdFactory.create());
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImpl.java
@@ -865,6 +865,101 @@ public class LoanChargeWritePlatformServiceImpl implements LoanChargeWritePlatfo
         }
     }
 
+    @Transactional
+    @Override
+    public void applyPeriodicChargesForLoan(final Long loanId) {
+        final Loan loan = this.loanAssembler.assembleFrom(loanId);
+        if (loan.isChargedOff() || !(loan.getStatus().isActive() || loan.getStatus().isOverpaid())) {
+            log.warn("Adding periodic charge to Loan: {} is not allowed. Loan Account is not open", loanId);
+            return;
+        }
+
+        final LocalDate businessDate = DateUtils.getBusinessLocalDate();
+        final LocalDate anchorDate = determinePeriodicChargeAnchorDate(loan);
+        if (anchorDate == null || DateUtils.isAfter(anchorDate, businessDate) || loan.getLoanProduct() == null
+                || loan.getLoanProduct().getCharges() == null) {
+            return;
+        }
+
+        final List<Charge> periodicCharges = loan.getLoanProduct().getCharges().stream().filter(Charge::isActive).filter(Charge::isLoanCharge)
+                .filter(Charge::isLoanPeriodic).toList();
+        if (periodicCharges.isEmpty()) {
+            return;
+        }
+
+        boolean runInterestRecalculation = false;
+        boolean chargesAdded = false;
+        LocalDate recalculateFrom = businessDate;
+        LocalDate lastChargeDate = null;
+        final Collection<LoanCharge> existingCharges = loan.getCharges() == null ? List.of() : loan.getCharges();
+
+        for (final Charge chargeDefinition : periodicCharges) {
+            final Set<LocalDate> existingDueDates = existingCharges.stream()
+                    .filter(existingCharge -> existingCharge.getCharge() != null
+                            && chargeDefinition.getId().equals(existingCharge.getCharge().getId()))
+                    .map(LoanCharge::getDueLocalDate).filter(dueDate -> dueDate != null).collect(HashSet::new, HashSet::add, HashSet::addAll);
+
+            for (final LocalDate occurrenceDate : calculatePeriodicChargeDates(chargeDefinition, anchorDate, businessDate)) {
+                if (existingDueDates.contains(occurrenceDate)) {
+                    continue;
+                }
+                final LoanCharge loanCharge = loanChargeAssembler.createNewFromChargeDefinition(loan, chargeDefinition, occurrenceDate);
+                if (BigDecimal.ZERO.compareTo(loanCharge.amount()) == 0) {
+                    continue;
+                }
+
+                final boolean appliedOnBackDate = addCharge(loan, chargeDefinition, loanCharge);
+                runInterestRecalculation = runInterestRecalculation || appliedOnBackDate;
+                if (DateUtils.isAfter(recalculateFrom, occurrenceDate)) {
+                    recalculateFrom = occurrenceDate;
+                }
+                if (lastChargeDate == null || DateUtils.isAfter(occurrenceDate, lastChargeDate)) {
+                    lastChargeDate = occurrenceDate;
+                }
+                existingDueDates.add(occurrenceDate);
+                chargesAdded = true;
+            }
+        }
+
+        if (!chargesAdded) {
+            return;
+        }
+
+        boolean reprocessRequired = true;
+        LocalDate recalculatedTill = loan.fetchInterestRecalculateFromDate();
+        if (recalculatedTill != null && DateUtils.isAfter(recalculateFrom, recalculatedTill)) {
+            recalculateFrom = recalculatedTill;
+        }
+
+        Loan loanToSave = loan;
+        if (loan.isInterestBearingAndInterestRecalculationEnabled()) {
+            if (runInterestRecalculation && loan.isFeeCompoundingEnabledForInterestRecalculation()) {
+                loanToSave = runScheduleRecalculation(loan, recalculateFrom);
+                reprocessRequired = false;
+            }
+            this.loanWritePlatformService.updateOriginalSchedule(loanToSave);
+        }
+
+        if (reprocessRequired) {
+            if (loanToSave.isProgressiveSchedule()) {
+                final ScheduleGeneratorDTO scheduleGeneratorDTO = loanUtilService.buildScheduleGeneratorDTO(loanToSave, null);
+                loanScheduleService.regenerateRepaymentSchedule(loanToSave, scheduleGeneratorDTO);
+            }
+            reprocessLoanTransactionsService.reprocessTransactions(loanToSave);
+            if (lastChargeDate != null) {
+                loanLifecycleStateMachine.determineAndTransition(loanToSave, lastChargeDate);
+            }
+            loanAccountService.saveAndFlushLoanWithDataIntegrityViolationChecks(loanToSave);
+        }
+
+        if (loanToSave.isInterestBearingAndInterestRecalculationEnabled() && runInterestRecalculation
+                && loanToSave.isFeeCompoundingEnabledForInterestRecalculation()) {
+            loanAccrualsProcessingService.processAccrualsOnInterestRecalculation(loanToSave, true, true);
+        }
+        this.loanAccountDomainService.setLoanDelinquencyTag(loanToSave, businessDate);
+        businessEventNotifierService.notifyPostBusinessEvent(new LoanBalanceChangedBusinessEvent(loanToSave));
+    }
+
     private LoanTransaction applyChargeAdjustment(final Loan loan, final LoanCharge loanCharge, final BigDecimal transactionAmount,
             final LocalDate transactionDate, final ExternalId txnExternalId, PaymentDetail paymentDetail) {
         businessEventNotifierService.notifyPreBusinessEvent(new LoanChargeAdjustmentPreBusinessEvent(loan));
@@ -1172,6 +1267,38 @@ public class LoanChargeWritePlatformServiceImpl implements LoanChargeWritePlatfo
                 loan.addLoanRepaymentScheduleInstallment(newEntry);
             }
         }
+    }
+
+    private LocalDate determinePeriodicChargeAnchorDate(final Loan loan) {
+        if (loan.getExpectedFirstRepaymentOnDate() != null) {
+            return loan.getExpectedFirstRepaymentOnDate();
+        }
+        if (loan.getRepaymentScheduleInstallments() == null) {
+            return null;
+        }
+        return loan.getRepaymentScheduleInstallments().stream().filter(installment -> !installment.isDownPayment())
+                .sorted((installment1, installment2) -> installment1.getInstallmentNumber()
+                        .compareTo(installment2.getInstallmentNumber()))
+                .map(LoanRepaymentScheduleInstallment::getDueDate).findFirst().orElse(null);
+    }
+
+    private List<LocalDate> calculatePeriodicChargeDates(final Charge chargeDefinition, final LocalDate anchorDate,
+            final LocalDate businessDate) {
+        if (chargeDefinition.feeInterval() == null || chargeDefinition.feeInterval() <= 0) {
+            return List.of();
+        }
+        final PeriodFrequencyType frequencyType = PeriodFrequencyType.fromInt(chargeDefinition.feeFrequency());
+        if (frequencyType.isInvalid() || frequencyType.isDaily() || frequencyType.isWholeTerm()) {
+            return List.of();
+        }
+
+        final List<LocalDate> occurrenceDates = new ArrayList<>();
+        LocalDate occurrenceDate = anchorDate;
+        while (!DateUtils.isAfter(occurrenceDate, businessDate)) {
+            occurrenceDates.add(occurrenceDate);
+            occurrenceDate = scheduledDateGenerator.getRepaymentPeriodDate(frequencyType, chargeDefinition.feeInterval(), occurrenceDate);
+        }
+        return occurrenceDates;
     }
 
     public Loan runScheduleRecalculation(Loan loan, final LocalDate recalculateFrom) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImpl.java
@@ -881,8 +881,8 @@ public class LoanChargeWritePlatformServiceImpl implements LoanChargeWritePlatfo
             return;
         }
 
-        final List<Charge> periodicCharges = loan.getLoanProduct().getCharges().stream().filter(Charge::isActive).filter(Charge::isLoanCharge)
-                .filter(Charge::isLoanPeriodic).toList();
+        final List<Charge> periodicCharges = loan.getLoanProduct().getCharges().stream().filter(Charge::isActive)
+                .filter(Charge::isLoanCharge).filter(Charge::isLoanPeriodic).toList();
         if (periodicCharges.isEmpty()) {
             return;
         }
@@ -897,7 +897,8 @@ public class LoanChargeWritePlatformServiceImpl implements LoanChargeWritePlatfo
             final Set<LocalDate> existingDueDates = existingCharges.stream()
                     .filter(existingCharge -> existingCharge.getCharge() != null
                             && chargeDefinition.getId().equals(existingCharge.getCharge().getId()))
-                    .map(LoanCharge::getDueLocalDate).filter(dueDate -> dueDate != null).collect(HashSet::new, HashSet::add, HashSet::addAll);
+                    .map(LoanCharge::getDueLocalDate).filter(dueDate -> dueDate != null)
+                    .collect(HashSet::new, HashSet::add, HashSet::addAll);
 
             for (final LocalDate occurrenceDate : calculatePeriodicChargeDates(chargeDefinition, anchorDate, businessDate)) {
                 if (existingDueDates.contains(occurrenceDate)) {
@@ -1277,8 +1278,7 @@ public class LoanChargeWritePlatformServiceImpl implements LoanChargeWritePlatfo
             return null;
         }
         return loan.getRepaymentScheduleInstallments().stream().filter(installment -> !installment.isDownPayment())
-                .sorted((installment1, installment2) -> installment1.getInstallmentNumber()
-                        .compareTo(installment2.getInstallmentNumber()))
+                .sorted((installment1, installment2) -> installment1.getInstallmentNumber().compareTo(installment2.getInstallmentNumber()))
                 .map(LoanRepaymentScheduleInstallment::getDueDate).findFirst().orElse(null);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -1490,10 +1490,11 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
         Collection<ChargeData> chargeOptions = null;
         if (loanProduct.getMultiDisburseLoan()) {
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT });
+                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.LOAN_PERIODIC });
         } else {
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT });
+                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT,
+                            ChargeTimeType.LOAN_PERIODIC });
         }
 
         Integer loanCycleCounter = null;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -1492,9 +1492,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
                     new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.LOAN_PERIODIC });
         } else {
-            chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT,
-                            ChargeTimeType.LOAN_PERIODIC });
+            chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId, new ChargeTimeType[] {
+                    ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT, ChargeTimeType.LOAN_PERIODIC });
         }
 
         Integer loanCycleCounter = null;

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImplTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeWritePlatformServiceImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.loanaccount.service;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -32,6 +34,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.stream.Stream;
 import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
@@ -45,6 +48,7 @@ import org.apache.fineract.portfolio.charge.domain.Charge;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeRepositoryWrapper;
+import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.loanaccount.data.AccountingBridgeDataDTO;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanAccountDomainService;
@@ -52,15 +56,19 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanAccountService;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanChargeRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanLifecycleStateMachine;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.SingleLoanChargeRepaymentScheduleProcessingWrapper;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.ScheduledDateGenerator;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanChargeApiJsonValidator;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanChargeValidator;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -168,6 +176,12 @@ class LoanChargeWritePlatformServiceImplTest {
     @Mock
     private LoanScheduleService loanScheduleService;
 
+    @Mock
+    private ScheduledDateGenerator scheduledDateGenerator;
+
+    @Mock
+    private LoanProduct loanProduct;
+
     @BeforeEach
     void setUp() {
         when(loanAssembler.assembleFrom(LOAN_ID)).thenReturn(loan);
@@ -179,17 +193,19 @@ class LoanChargeWritePlatformServiceImplTest {
         when(loanRepaymentScheduleDetail.getLoanScheduleType()).thenReturn(LoanScheduleType.CUMULATIVE);
         when(loan.getLoanRepaymentScheduleDetail()).thenReturn(loanRepaymentScheduleDetail);
         when(loan.hasCurrencyCodeOf(CURRENCY_CODE)).thenReturn(true);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
         when(loanCharge.getChargePaymentMode()).thenReturn(ChargePaymentMode.REGULAR);
         when(loanCharge.getChargeCalculation()).thenReturn(chargeCalculationType);
         when(chargeCalculationType.isPercentageBased()).thenReturn(false);
         when(loanCharge.amountOrPercentage()).thenReturn(BigDecimal.TEN);
         when(loan.getStatus()).thenReturn(LoanStatus.ACTIVE);
-        when(loanChargeRepository.saveAndFlush(any(LoanCharge.class))).thenReturn(loanCharge);
+        when(loanChargeRepository.saveAndFlush(any(LoanCharge.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(loan.getCurrency()).thenReturn(monetaryCurrency);
         when(monetaryCurrency.getCode()).thenReturn(CURRENCY_CODE);
         when(loanAccountService.saveAndFlushLoanWithDataIntegrityViolationChecks(any())).thenReturn(loan);
 
         when(loan.getLoanCharges()).thenReturn(new HashSet<>());
+        when(loan.getCharges()).thenReturn(new ArrayList<>());
         when(loan.getDisbursementDate()).thenReturn(LocalDate.now(ZoneId.systemDefault()));
         when(loan.getRepaymentScheduleInstallments()).thenReturn(new ArrayList<>());
         when(loanChargeService.calculateAmountPercentageAppliedTo(any(Loan.class), any(LoanCharge.class))).thenReturn(BigDecimal.TEN);
@@ -239,9 +255,125 @@ class LoanChargeWritePlatformServiceImplTest {
         }
     }
 
+    @Test
+    void applyPeriodicChargesForLoanBackfillsMissingYearlyOccurrencesFromExpectedFirstRepaymentDate() {
+        final LocalDate anchorDate = LocalDate.of(2024, 2, 15);
+        final LocalDate nextOccurrence = LocalDate.of(2025, 2, 15);
+        final LocalDate businessDate = LocalDate.of(2025, 3, 12);
+        when(loan.getExpectedFirstRepaymentOnDate()).thenReturn(anchorDate);
+        when(loanProduct.getCharges()).thenReturn(List.of(chargeDefinition));
+        when(chargeDefinition.isActive()).thenReturn(true);
+        when(chargeDefinition.isLoanCharge()).thenReturn(true);
+        when(chargeDefinition.isLoanPeriodic()).thenReturn(true);
+        when(chargeDefinition.getId()).thenReturn(100L);
+        when(chargeDefinition.feeFrequency()).thenReturn(PeriodFrequencyType.YEARS.getValue());
+        when(chargeDefinition.feeInterval()).thenReturn(1);
+        when(scheduledDateGenerator.getRepaymentPeriodDate(PeriodFrequencyType.YEARS, 1, anchorDate)).thenReturn(nextOccurrence);
+        when(scheduledDateGenerator.getRepaymentPeriodDate(PeriodFrequencyType.YEARS, 1, nextOccurrence))
+                .thenReturn(nextOccurrence.plusYears(1));
+        LoanCharge firstPeriodicCharge = materializedCharge(anchorDate);
+        LoanCharge secondPeriodicCharge = materializedCharge(nextOccurrence);
+        when(loanChargeAssembler.createNewFromChargeDefinition(loan, chargeDefinition, anchorDate)).thenReturn(firstPeriodicCharge);
+        when(loanChargeAssembler.createNewFromChargeDefinition(loan, chargeDefinition, nextOccurrence)).thenReturn(secondPeriodicCharge);
+
+        try (MockedStatic<DateUtils> mockedDateUtils = mockStatic(DateUtils.class, org.mockito.Answers.CALLS_REAL_METHODS)) {
+            mockedDateUtils.when(DateUtils::getBusinessLocalDate).thenReturn(businessDate);
+
+            loanChargeWritePlatformService.applyPeriodicChargesForLoan(LOAN_ID);
+        }
+
+        verify(loanChargeAssembler, times(1)).createNewFromChargeDefinition(loan, chargeDefinition, anchorDate);
+        verify(loanChargeAssembler, times(1)).createNewFromChargeDefinition(loan, chargeDefinition, nextOccurrence);
+        verify(reprocessLoanTransactionsService, times(1)).reprocessTransactions(loan);
+        verify(loanLifecycleStateMachine, times(1)).determineAndTransition(loan, nextOccurrence);
+        verify(loanAccountService, times(1)).saveAndFlushLoanWithDataIntegrityViolationChecks(loan);
+        verify(loanAccountDomainService, times(1)).setLoanDelinquencyTag(loan, businessDate);
+    }
+
+    @Test
+    void applyPeriodicChargesForLoanUsesRepaymentScheduleFallbackAndSkipsExistingOccurrences() {
+        final LocalDate anchorDate = LocalDate.of(2024, 2, 15);
+        final LocalDate secondOccurrence = LocalDate.of(2024, 5, 15);
+        final LocalDate thirdOccurrence = LocalDate.of(2024, 8, 15);
+        final LocalDate businessDate = LocalDate.of(2024, 8, 15);
+        LoanRepaymentScheduleInstallment downPayment = repaymentInstallment(1, LocalDate.of(2024, 1, 15), true);
+        LoanRepaymentScheduleInstallment firstRepayment = repaymentInstallment(2, anchorDate, false);
+        LoanCharge existingCharge = existingCharge(anchorDate);
+        when(loan.getExpectedFirstRepaymentOnDate()).thenReturn(null);
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(firstRepayment, downPayment));
+        when(loan.getCharges()).thenReturn(List.of(existingCharge));
+        when(loanProduct.getCharges()).thenReturn(List.of(chargeDefinition));
+        when(chargeDefinition.isActive()).thenReturn(true);
+        when(chargeDefinition.isLoanCharge()).thenReturn(true);
+        when(chargeDefinition.isLoanPeriodic()).thenReturn(true);
+        when(chargeDefinition.getId()).thenReturn(100L);
+        when(chargeDefinition.feeFrequency()).thenReturn(PeriodFrequencyType.MONTHS.getValue());
+        when(chargeDefinition.feeInterval()).thenReturn(3);
+        when(scheduledDateGenerator.getRepaymentPeriodDate(PeriodFrequencyType.MONTHS, 3, anchorDate)).thenReturn(secondOccurrence);
+        when(scheduledDateGenerator.getRepaymentPeriodDate(PeriodFrequencyType.MONTHS, 3, secondOccurrence)).thenReturn(thirdOccurrence);
+        when(scheduledDateGenerator.getRepaymentPeriodDate(PeriodFrequencyType.MONTHS, 3, thirdOccurrence))
+                .thenReturn(thirdOccurrence.plusMonths(3));
+        LoanCharge secondPeriodicCharge = materializedCharge(secondOccurrence);
+        LoanCharge thirdPeriodicCharge = materializedCharge(thirdOccurrence);
+        when(loanChargeAssembler.createNewFromChargeDefinition(loan, chargeDefinition, secondOccurrence)).thenReturn(secondPeriodicCharge);
+        when(loanChargeAssembler.createNewFromChargeDefinition(loan, chargeDefinition, thirdOccurrence)).thenReturn(thirdPeriodicCharge);
+
+        try (MockedStatic<DateUtils> mockedDateUtils = mockStatic(DateUtils.class, org.mockito.Answers.CALLS_REAL_METHODS)) {
+            mockedDateUtils.when(DateUtils::getBusinessLocalDate).thenReturn(businessDate);
+
+            loanChargeWritePlatformService.applyPeriodicChargesForLoan(LOAN_ID);
+        }
+
+        verify(loanChargeAssembler, never()).createNewFromChargeDefinition(loan, chargeDefinition, anchorDate);
+        verify(loanChargeAssembler, times(1)).createNewFromChargeDefinition(loan, chargeDefinition, secondOccurrence);
+        verify(loanChargeAssembler, times(1)).createNewFromChargeDefinition(loan, chargeDefinition, thirdOccurrence);
+        verify(loanLifecycleStateMachine, times(1)).determineAndTransition(loan, thirdOccurrence);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonOpenLoanStates")
+    void applyPeriodicChargesForLoanSkipsClosedAndChargedOffLoans(final boolean chargedOff, final LoanStatus status) {
+        when(loan.isChargedOff()).thenReturn(chargedOff);
+        when(loan.getStatus()).thenReturn(status);
+
+        loanChargeWritePlatformService.applyPeriodicChargesForLoan(LOAN_ID);
+
+        verifyNoInteractions(loanChargeAssembler, reprocessLoanTransactionsService, loanLifecycleStateMachine);
+    }
+
     private static Stream<Arguments> loanChargeAccrualTestCases() {
         return Stream.of(Arguments.of(true, BUSINESS_DATE_AFTER, MATURITY_DATE, true),
                 Arguments.of(false, BUSINESS_DATE_AFTER, MATURITY_DATE, false), Arguments.of(true, BUSINESS_DATE_ON, MATURITY_DATE, false),
                 Arguments.of(true, BUSINESS_DATE_BEFORE, MATURITY_DATE, false));
+    }
+
+    private static Stream<Arguments> nonOpenLoanStates() {
+        return Stream.of(Arguments.of(false, LoanStatus.CLOSED_OBLIGATIONS_MET), Arguments.of(true, LoanStatus.ACTIVE));
+    }
+
+    private LoanCharge materializedCharge(final LocalDate dueDate) {
+        LoanCharge createdCharge = org.mockito.Mockito.mock(LoanCharge.class);
+        when(createdCharge.amount()).thenReturn(BigDecimal.TEN);
+        when(createdCharge.getDueLocalDate()).thenReturn(dueDate);
+        when(createdCharge.getEffectiveDueDate()).thenReturn(dueDate);
+        when(createdCharge.getChargePaymentMode()).thenReturn(ChargePaymentMode.REGULAR);
+        when(createdCharge.getChargeCalculation()).thenReturn(chargeCalculationType);
+        return createdCharge;
+    }
+
+    private LoanCharge existingCharge(final LocalDate dueDate) {
+        LoanCharge existingCharge = org.mockito.Mockito.mock(LoanCharge.class);
+        when(existingCharge.getCharge()).thenReturn(chargeDefinition);
+        when(existingCharge.getDueLocalDate()).thenReturn(dueDate);
+        return existingCharge;
+    }
+
+    private LoanRepaymentScheduleInstallment repaymentInstallment(final Integer installmentNumber, final LocalDate dueDate,
+            final boolean downPayment) {
+        LoanRepaymentScheduleInstallment installment = org.mockito.Mockito.mock(LoanRepaymentScheduleInstallment.class);
+        when(installment.getInstallmentNumber()).thenReturn(installmentNumber);
+        when(installment.getDueDate()).thenReturn(dueDate);
+        when(installment.isDownPayment()).thenReturn(downPayment);
+        return installment;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanPeriodicChargeIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanPeriodicChargeIntegrationTest.java
@@ -42,8 +42,8 @@ import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
-import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.Test;
 
 public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
@@ -126,8 +126,8 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
             Integer createdFinancialActivityMappingId = ensureLiabilityTransferFinancialActivityMapping();
             SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
             try {
-                double accountBalanceBefore = ((Number) savingsAccountHelper.getSavingsSummary(context.savingsAccountId()).get("accountBalance"))
-                        .doubleValue();
+                double accountBalanceBefore = ((Number) savingsAccountHelper.getSavingsSummary(context.savingsAccountId())
+                        .get("accountBalance")).doubleValue();
 
                 schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
                 schedulerJobHelper.executeAndAwaitJobByShortName(TRANSFER_FEE_JOB_SHORT_NAME);
@@ -138,8 +138,8 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
                 assertEquals(0.0, Utils.getDoubleValue(firstPeriod.getFeeChargesOutstanding()));
                 assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(firstPeriod.getFeeChargesPaid()));
 
-                double accountBalanceAfter = ((Number) savingsAccountHelper.getSavingsSummary(context.savingsAccountId()).get("accountBalance"))
-                        .doubleValue();
+                double accountBalanceAfter = ((Number) savingsAccountHelper.getSavingsSummary(context.savingsAccountId())
+                        .get("accountBalance")).doubleValue();
                 assertEquals(accountBalanceBefore - PERIODIC_CHARGE_AMOUNT, accountBalanceAfter);
             } finally {
                 cleanupFinancialActivityMapping(createdFinancialActivityMappingId);
@@ -149,18 +149,20 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
 
     private PeriodicLoanContext createPeriodicLoan(final int numberOfRepayments) {
         Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-        Long periodicChargeId = new ChargesHelper().createCharges(ChargesHelper.loanPeriodicChargeRequest(PERIODIC_CHARGE_AMOUNT,
-                ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS, 1)).getResourceId();
+        Long periodicChargeId = new ChargesHelper()
+                .createCharges(ChargesHelper.loanPeriodicChargeRequest(PERIODIC_CHARGE_AMOUNT, ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS, 1))
+                .getResourceId();
 
-        PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().numberOfRepayments(numberOfRepayments)
-                .repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L).multiDisburseLoan(false)
-                .disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null)
-                .overAppliedCalculationType(null).charges(List.of(new LoanProductChargeData().id(periodicChargeId)));
+        PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
+                .numberOfRepayments(numberOfRepayments).repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L)
+                .multiDisburseLoan(false).disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(false)
+                .overAppliedNumber(null).overAppliedCalculationType(null)
+                .charges(List.of(new LoanProductChargeData().id(periodicChargeId)));
 
         Long loanProductId = loanProductHelper.createLoanProduct(loanProduct).getResourceId();
-        Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DISBURSEMENT_DATE, 1000.0, numberOfRepayments, request -> request
-                .repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS).loanTermFrequency(numberOfRepayments)
-                .loanTermFrequencyType(RepaymentFrequencyType.MONTHS));
+        Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DISBURSEMENT_DATE, 1000.0, numberOfRepayments,
+                request -> request.repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS)
+                        .loanTermFrequency(numberOfRepayments).loanTermFrequencyType(RepaymentFrequencyType.MONTHS));
         disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DISBURSEMENT_DATE);
 
         assertEquals(0, loanTransactionHelper.getLoanCharges(loanId).size());
@@ -177,15 +179,14 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
         savingsAccountHelper.depositToSavingsAccount(savingsAccountId, "10000", LOAN_DISBURSEMENT_DATE,
                 CommonConstants.RESPONSE_RESOURCE_ID);
 
-        Long periodicChargeId = new ChargesHelper()
-                .createCharges(ChargesHelper.loanPeriodicChargeRequest(PERIODIC_CHARGE_AMOUNT, ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS,
-                        1, ChargePaymentMode.ACCOUNT_TRANSFER.getValue()))
-                .getResourceId();
+        Long periodicChargeId = new ChargesHelper().createCharges(ChargesHelper.loanPeriodicChargeRequest(PERIODIC_CHARGE_AMOUNT,
+                ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS, 1, ChargePaymentMode.ACCOUNT_TRANSFER.getValue())).getResourceId();
 
-        PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().numberOfRepayments(numberOfRepayments)
-                .repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L).multiDisburseLoan(false)
-                .disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null)
-                .overAppliedCalculationType(null).charges(List.of(new LoanProductChargeData().id(periodicChargeId)));
+        PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
+                .numberOfRepayments(numberOfRepayments).repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L)
+                .multiDisburseLoan(false).disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(false)
+                .overAppliedNumber(null).overAppliedCalculationType(null)
+                .charges(List.of(new LoanProductChargeData().id(periodicChargeId)));
 
         Long loanProductId = loanProductHelper.createLoanProduct(loanProduct).getResourceId();
         String loanApplicationJson = new LoanApplicationTestBuilder().withPrincipal("1000.0")
@@ -210,10 +211,10 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
 
     private Integer createSavingsAccountDailyPosting(final SavingsAccountHelper savingsAccountHelper, final Integer clientId,
             final String startDate) {
-        Integer savingsProductId = SavingsProductHelper.createSavingsProduct(new SavingsProductHelper()
-                .withInterestCompoundingPeriodTypeAsDaily().withInterestPostingPeriodTypeAsMonthly()
-                .withInterestCalculationPeriodTypeAsDailyBalance().withMinimumOpenningBalance("10000.0").build(), requestSpec,
-                responseSpec);
+        Integer savingsProductId = SavingsProductHelper.createSavingsProduct(
+                new SavingsProductHelper().withInterestCompoundingPeriodTypeAsDaily().withInterestPostingPeriodTypeAsMonthly()
+                        .withInterestCalculationPeriodTypeAsDailyBalance().withMinimumOpenningBalance("10000.0").build(),
+                requestSpec, responseSpec);
         Integer savingsAccountId = savingsAccountHelper.applyForSavingsApplicationOnDate(clientId, savingsProductId,
                 SavingsAccountHelper.ACCOUNT_TYPE_INDIVIDUAL, startDate);
         savingsAccountHelper.approveSavingsOnDate(savingsAccountId, startDate);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanPeriodicChargeIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanPeriodicChargeIntegrationTest.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests;
+
+import static org.apache.fineract.accounting.common.AccountingConstants.FinancialActivity.LIABILITY_TRANSFER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
+import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdResponse;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.accounting.Account;
+import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
+import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
+import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
+import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
+import org.junit.jupiter.api.Test;
+
+public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
+
+    private static final double PERIODIC_CHARGE_AMOUNT = 100.0;
+    private static final String PERIODIC_JOB_SHORT_NAME = "LA_PLC";
+    private static final String TRANSFER_FEE_JOB_SHORT_NAME = "LA_TFFS";
+    private static final String LOAN_DISBURSEMENT_DATE = "01 January 2024";
+
+    @Test
+    public void testPeriodicLoanChargeGeneratesOnAnchorDateAndIsIdempotent() {
+        AtomicReference<PeriodicLoanContext> contextRef = new AtomicReference<>();
+
+        runAt(LOAN_DISBURSEMENT_DATE, () -> contextRef.set(createPeriodicLoan(6)));
+
+        PeriodicLoanContext context = contextRef.get();
+        String firstRepaymentDate = formatDate(context.firstRepaymentDate());
+
+        runAt(firstRepaymentDate, () -> {
+            schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
+
+            List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = loanTransactionHelper.getLoanCharges(context.loanId());
+            assertEquals(1, loanCharges.size());
+
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(context.loanId());
+            GetLoansLoanIdRepaymentPeriod firstPeriod = repaymentPeriod(loanDetails, 1);
+            assertEquals(context.firstRepaymentDate(), firstPeriod.getDueDate());
+            assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(firstPeriod.getFeeChargesDue()));
+            assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(firstPeriod.getFeeChargesOutstanding()));
+
+            schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
+            assertEquals(1, loanTransactionHelper.getLoanCharges(context.loanId()).size());
+        });
+    }
+
+    @Test
+    public void testPeriodicLoanChargeBackfillsPastMaturityAndStopsOnceLoanIsClosed() {
+        AtomicReference<PeriodicLoanContext> contextRef = new AtomicReference<>();
+
+        runAt(LOAN_DISBURSEMENT_DATE, () -> contextRef.set(createPeriodicLoan(6)));
+
+        PeriodicLoanContext context = contextRef.get();
+        LocalDate secondAnnualChargeDate = context.firstRepaymentDate().plusYears(1);
+        LocalDate thirdAnnualChargeDate = context.firstRepaymentDate().plusYears(2);
+
+        runAt(formatDate(secondAnnualChargeDate), () -> {
+            schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
+
+            List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = loanTransactionHelper.getLoanCharges(context.loanId());
+            assertEquals(2, loanCharges.size());
+
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(context.loanId());
+            GetLoansLoanIdRepaymentPeriod annualChargePeriod = loanDetails.getRepaymentSchedule().getPeriods().stream()
+                    .filter(period -> secondAnnualChargeDate.equals(period.getDueDate())).findFirst().orElseThrow();
+            assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(annualChargePeriod.getFeeChargesDue()));
+            assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(annualChargePeriod.getFeeChargesOutstanding()));
+
+            verifyPrepayAmountByRepayment(context.loanId(), formatDate(secondAnnualChargeDate));
+            verifyLoanStatus(context.loanId(), LoanStatus.CLOSED_OBLIGATIONS_MET);
+        });
+
+        runAt(formatDate(thirdAnnualChargeDate), () -> {
+            schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
+
+            assertEquals(2, loanTransactionHelper.getLoanCharges(context.loanId()).size());
+            verifyLoanStatus(context.loanId(), LoanStatus.CLOSED_OBLIGATIONS_MET);
+        });
+    }
+
+    @Test
+    public void testPeriodicLoanChargeWithAccountTransferGetsPaidFromLinkedSavings() {
+        AtomicReference<PeriodicLoanContext> contextRef = new AtomicReference<>();
+
+        runAt(LOAN_DISBURSEMENT_DATE, () -> contextRef.set(createPeriodicLoanWithLinkedSavings(6)));
+
+        PeriodicLoanContext context = contextRef.get();
+        String firstRepaymentDate = formatDate(context.firstRepaymentDate());
+
+        runAt(firstRepaymentDate, () -> {
+            Integer createdFinancialActivityMappingId = ensureLiabilityTransferFinancialActivityMapping();
+            SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
+            try {
+                double accountBalanceBefore = ((Number) savingsAccountHelper.getSavingsSummary(context.savingsAccountId()).get("accountBalance"))
+                        .doubleValue();
+
+                schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
+                schedulerJobHelper.executeAndAwaitJobByShortName(TRANSFER_FEE_JOB_SHORT_NAME);
+
+                GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(context.loanId());
+                GetLoansLoanIdRepaymentPeriod firstPeriod = repaymentPeriod(loanDetails, 1);
+                assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(firstPeriod.getFeeChargesDue()));
+                assertEquals(0.0, Utils.getDoubleValue(firstPeriod.getFeeChargesOutstanding()));
+                assertEquals(PERIODIC_CHARGE_AMOUNT, Utils.getDoubleValue(firstPeriod.getFeeChargesPaid()));
+
+                double accountBalanceAfter = ((Number) savingsAccountHelper.getSavingsSummary(context.savingsAccountId()).get("accountBalance"))
+                        .doubleValue();
+                assertEquals(accountBalanceBefore - PERIODIC_CHARGE_AMOUNT, accountBalanceAfter);
+            } finally {
+                cleanupFinancialActivityMapping(createdFinancialActivityMappingId);
+            }
+        });
+    }
+
+    private PeriodicLoanContext createPeriodicLoan(final int numberOfRepayments) {
+        Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        Long periodicChargeId = new ChargesHelper().createCharges(ChargesHelper.loanPeriodicChargeRequest(PERIODIC_CHARGE_AMOUNT,
+                ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS, 1)).getResourceId();
+
+        PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().numberOfRepayments(numberOfRepayments)
+                .repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L).multiDisburseLoan(false)
+                .disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null)
+                .overAppliedCalculationType(null).charges(List.of(new LoanProductChargeData().id(periodicChargeId)));
+
+        Long loanProductId = loanProductHelper.createLoanProduct(loanProduct).getResourceId();
+        Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DISBURSEMENT_DATE, 1000.0, numberOfRepayments, request -> request
+                .repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS).loanTermFrequency(numberOfRepayments)
+                .loanTermFrequencyType(RepaymentFrequencyType.MONTHS));
+        disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DISBURSEMENT_DATE);
+
+        assertEquals(0, loanTransactionHelper.getLoanCharges(loanId).size());
+
+        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        LocalDate firstRepaymentDate = repaymentPeriod(loanDetails, 1).getDueDate();
+        return new PeriodicLoanContext(loanId, firstRepaymentDate, null);
+    }
+
+    private PeriodicLoanContext createPeriodicLoanWithLinkedSavings(final int numberOfRepayments) {
+        Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
+        Integer savingsAccountId = createSavingsAccountDailyPosting(savingsAccountHelper, clientId.intValue(), LOAN_DISBURSEMENT_DATE);
+        savingsAccountHelper.depositToSavingsAccount(savingsAccountId, "10000", LOAN_DISBURSEMENT_DATE,
+                CommonConstants.RESPONSE_RESOURCE_ID);
+
+        Long periodicChargeId = new ChargesHelper()
+                .createCharges(ChargesHelper.loanPeriodicChargeRequest(PERIODIC_CHARGE_AMOUNT, ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS,
+                        1, ChargePaymentMode.ACCOUNT_TRANSFER.getValue()))
+                .getResourceId();
+
+        PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().numberOfRepayments(numberOfRepayments)
+                .repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L).multiDisburseLoan(false)
+                .disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null)
+                .overAppliedCalculationType(null).charges(List.of(new LoanProductChargeData().id(periodicChargeId)));
+
+        Long loanProductId = loanProductHelper.createLoanProduct(loanProduct).getResourceId();
+        String loanApplicationJson = new LoanApplicationTestBuilder().withPrincipal("1000.0")
+                .withLoanTermFrequency(String.valueOf(numberOfRepayments)).withLoanTermFrequencyAsMonths()
+                .withNumberOfRepayments(String.valueOf(numberOfRepayments)).withRepaymentEveryAfter("1")
+                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance()
+                .withAmortizationTypeAsEqualInstallments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
+                .withExpectedDisbursementDate(LOAN_DISBURSEMENT_DATE).withSubmittedOnDate(LOAN_DISBURSEMENT_DATE)
+                .build(clientId.toString(), loanProductId.toString(), savingsAccountId.toString());
+
+        Long submittedLoanId = ((Number) loanTransactionHelper.createLoanAccount(loanApplicationJson, CommonConstants.RESPONSE_RESOURCE_ID))
+                .longValue();
+        PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(submittedLoanId,
+                approveLoanRequest(1000.0, LOAN_DISBURSEMENT_DATE));
+        Long loanId = approvedLoanResult.getLoanId();
+        disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DISBURSEMENT_DATE);
+
+        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        LocalDate firstRepaymentDate = repaymentPeriod(loanDetails, 1).getDueDate();
+        return new PeriodicLoanContext(loanId, firstRepaymentDate, savingsAccountId);
+    }
+
+    private Integer createSavingsAccountDailyPosting(final SavingsAccountHelper savingsAccountHelper, final Integer clientId,
+            final String startDate) {
+        Integer savingsProductId = SavingsProductHelper.createSavingsProduct(new SavingsProductHelper()
+                .withInterestCompoundingPeriodTypeAsDaily().withInterestPostingPeriodTypeAsMonthly()
+                .withInterestCalculationPeriodTypeAsDailyBalance().withMinimumOpenningBalance("10000.0").build(), requestSpec,
+                responseSpec);
+        Integer savingsAccountId = savingsAccountHelper.applyForSavingsApplicationOnDate(clientId, savingsProductId,
+                SavingsAccountHelper.ACCOUNT_TYPE_INDIVIDUAL, startDate);
+        savingsAccountHelper.approveSavingsOnDate(savingsAccountId, startDate);
+        savingsAccountHelper.activateSavingsAccount(savingsAccountId, startDate);
+        return savingsAccountId;
+    }
+
+    private GetLoansLoanIdRepaymentPeriod repaymentPeriod(final GetLoansLoanIdResponse loanDetails, final Integer periodNumber) {
+        return loanDetails.getRepaymentSchedule().getPeriods().stream().filter(period -> Objects.equals(period.getPeriod(), periodNumber))
+                .findFirst().orElseThrow();
+    }
+
+    private String formatDate(final LocalDate date) {
+        return date.format(dateTimeFormatter);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Integer ensureLiabilityTransferFinancialActivityMapping() {
+        FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
+        List<HashMap> financialActivities = financialActivityAccountHelper.getAllFinancialActivityAccounts(responseSpec);
+        for (HashMap financialActivity : financialActivities) {
+            HashMap financialActivityData = (HashMap) financialActivity.get("financialActivityData");
+            if (Objects.equals(financialActivityData.get("id"), FinancialActivityAccountsTest.LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID)) {
+                return null;
+            }
+        }
+
+        Account liabilityTransferAccount = accountHelper.createLiabilityAccount("periodicChargeTransfer");
+        return (Integer) financialActivityAccountHelper.createFinancialActivityAccount(LIABILITY_TRANSFER.getValue(),
+                liabilityTransferAccount.getAccountID(), responseSpec, CommonConstants.RESPONSE_RESOURCE_ID);
+    }
+
+    private void cleanupFinancialActivityMapping(final Integer financialActivityMappingId) {
+        if (financialActivityMappingId == null) {
+            return;
+        }
+
+        FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
+        financialActivityAccountHelper.deleteFinancialActivityAccount(financialActivityMappingId, responseSpec,
+                CommonConstants.RESPONSE_RESOURCE_ID);
+    }
+
+    private record PeriodicLoanContext(Long loanId, LocalDate firstRepaymentDate, Integer savingsAccountId) {
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test;
 @Order(1)
 public class SchedulerJobsTest {
 
+    private static final String PERIODIC_LOAN_CHARGES_JOB_NAME = "Apply Periodic Loan Charges";
     private final Map<Integer, Boolean> originalJobStatus = new HashMap<>();
     private RequestSpecification requestSpec;
     private SchedulerJobHelper schedulerJobHelper;
@@ -106,7 +108,9 @@ public class SchedulerJobsTest {
     @Test
     public void testNumberOfJobs() {
         List<Integer> jobIds = schedulerJobHelper.getAllSchedulerJobIds();
-        assertEquals(JobName.values().length, jobIds.size(), "Number of jobs in database and code do not match: " + jobIds);
+        assertTrue(schedulerJobHelper.getAllSchedulerJobNames().contains(PERIODIC_LOAN_CHARGES_JOB_NAME),
+                "Expected custom periodic loan charges job to be registered");
+        assertEquals(JobName.values().length + 1, jobIds.size(), "Number of jobs in database and code do not match: " + jobIds);
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/charges/ChargesHelper.java
@@ -31,6 +31,7 @@ import org.apache.fineract.client.util.JSON;
 import org.apache.fineract.integrationtests.common.CommonConstants;
 import org.apache.fineract.integrationtests.common.FineractClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,7 @@ public final class ChargesHelper {
     public static final Integer SHAREACCOUNT_ACTIVATION = 13;
     public static final Integer SHARE_PURCHASE = 14;
     public static final Integer SHARE_REDEEM = 15;
+    public static final Integer CHARGE_LOAN_PERIODIC = 17;
 
     public static final Integer CHARGE_CALCULATION_TYPE_FLAT = 1;
     public static final Integer CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT = 2;
@@ -810,5 +812,18 @@ public final class ChargesHelper {
 
     public GetChargesResponse retrieveCharge(final Long chargeId) {
         return Calls.ok(FineractClientHelper.getFineractClient().charges.retrieveCharge(chargeId));
+    }
+
+    public static ChargeRequest loanPeriodicChargeRequest(final Double amount, final Integer feeFrequency, final Integer feeInterval) {
+        return loanPeriodicChargeRequest(amount, feeFrequency, feeInterval, ChargePaymentMode.REGULAR.getValue());
+    }
+
+    public static ChargeRequest loanPeriodicChargeRequest(final Double amount, final Integer feeFrequency, final Integer feeInterval,
+            final Integer chargePaymentMode) {
+        return new ChargeRequest().active(true).amount(amount).chargeAppliesTo(CHARGE_APPLIES_TO_LOAN)
+                .chargeCalculationType(CHARGE_CALCULATION_TYPE_FLAT).chargeTimeType(CHARGE_LOAN_PERIODIC)
+                .chargePaymentMode(chargePaymentMode).currencyCode(CURRENCY_CODE).locale("en").penalty(false)
+                .feeFrequency(String.valueOf(feeFrequency)).feeInterval(String.valueOf(feeInterval))
+                .name(Utils.uniqueRandomStringGenerator("Charge_Loan_Periodic_", 6));
     }
 }


### PR DESCRIPTION
## Summary
- Introduces recurring loan fees independent of installment cadence.
- Supports annual insurance-style fees on monthly-repayment loans.
- Uses existing charge recurrence fields and materializes due charges via a new `mnzl` job.

## Key implementation notes
- `LOAN_PERIODIC` is loan-only and requires valid `feeFrequency` plus `feeInterval`.
- Periodic charges are excluded from manual loan charge add/template flows.
- Due dates are generated from `expectedFirstRepaymentOnDate`, with schedule fallback.
- Existing transfer-from-savings behavior works for periodic charges with `ACCOUNT_TRANSFER`.

## Database/config note
- Adds the new custom job row in the Liquibase changelog with `short_name = LA_PLC`.

## Verification
- `./gradlew :fineract-charge:test --tests 'org.apache.fineract.portfolio.charge.serialization.ChargeDefinitionCommandFromApiJsonDeserializerTest' --tests 'org.apache.fineract.portfolio.charge.service.ChargeDropdownReadPlatformServiceImplTest' --console=plain`
- `./gradlew :fineract-loan:test --tests 'org.apache.fineract.portfolio.loanaccount.serialization.LoanChargeApiJsonValidatorTest' --tests 'org.apache.fineract.portfolio.loanaccount.domain.SingleLoanChargeRepaymentScheduleProcessingWrapperTest' :custom:mnzl:loan:job:test --tests 'co.mnzl.fineract.custom.loan.job.*' :fineract-provider:test --tests 'org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformServiceImplTest' --console=plain`
- `./gradlew :integration-tests:test -PcargoDisabled --tests 'org.apache.fineract.integrationtests.LoanPeriodicChargeIntegrationTest' --console=plain`
- All three periodic-charge integration tests passed.

## Test setup note
- The account-transfer integration scenario provisions the `LIABILITY_TRANSFER` financial activity mapping inside the test setup before running the existing transfer-fee job.