### PR TITLE
Retry transient standing instruction loan conflicts

### DIFF
--- a/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlExecuteStandingInstructionsTasklet.java
+++ b/custom/mnzl/loan/job/src/main/java/co/mnzl/fineract/custom/loan/job/MnzlExecuteStandingInstructionsTasklet.java
@@ -18,6 +18,7 @@
  */
 package co.mnzl.fineract.custom.loan.job;
 
+import jakarta.persistence.OptimisticLockException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.lang.NonNull;
 import org.springframework.transaction.TransactionDefinition;
@@ -57,6 +59,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class MnzlExecuteStandingInstructionsTasklet extends ExecuteStandingInstructionsTasklet {
 
     private static final Logger LOG = LoggerFactory.getLogger(MnzlExecuteStandingInstructionsTasklet.class);
+    private static final int MAX_TRANSFER_ATTEMPTS = 6;
+    private static final int MAX_ERROR_LOG_LENGTH = 500;
 
     private final StandingInstructionReadPlatformService standingInstructionReadPlatformService;
     private final JdbcTemplate jdbcTemplate;
@@ -128,11 +132,7 @@ public class MnzlExecuteStandingInstructionsTasklet extends ExecuteStandingInstr
                         data.getName() + " Standing instruction trasfer ", null, null, null, null, data.toTransferType(), null, null,
                         data.getTransferType().getValue(), null, null, ExternalId.empty(), null, null, fromSavingsAccount,
                         isRegularTransaction, isExceptionForBalanceCheck);
-                final boolean transferCompleted = transferAmount(errors, accountTransferDTO, data.getId());
-
-                if (transferCompleted) {
-                    updateLastRunDate(transactionDate, data.getId());
-                }
+                transferAmount(errors, accountTransferDTO, data.getId());
             }
         }
         if (!errors.isEmpty()) {
@@ -144,42 +144,117 @@ public class MnzlExecuteStandingInstructionsTasklet extends ExecuteStandingInstr
     }
 
     private boolean transferAmount(final List<Throwable> errors, final AccountTransferDTO accountTransferDTO, final Long instructionId) {
-        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-
-        boolean transferCompleted = false;
-        StringBuilder errorLog = new StringBuilder();
-
-        try {
-            transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-
-                @Override
-                protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
+        for (int attempt = 1; attempt <= MAX_TRANSFER_ATTEMPTS; attempt++) {
+            try {
+                executeInNewTransaction(() -> {
                     accountTransfersWritePlatformService.transferFunds(accountTransferDTO);
+                    updateLastRunDate(accountTransferDTO.getTransactionDate(), instructionId);
+                    logTransferHistory(instructionId, accountTransferDTO.getTransactionAmount(), true, "");
                     LOG.debug("Successfully transferred standing instruction {} for amount {}", instructionId,
                             accountTransferDTO.getTransactionAmount());
+                });
+                return true;
+            } catch (Exception e) {
+                if (isRetryableOptimisticLock(e) && attempt < MAX_TRANSFER_ATTEMPTS) {
+                    long retryDelayMillis = calculateRetryDelayMillis(attempt);
+                    LOG.warn("Retrying standing instruction {} after optimistic lock on attempt {}/{} in {} ms: {}", instructionId, attempt,
+                            MAX_TRANSFER_ATTEMPTS, retryDelayMillis, e.getMessage());
+                    try {
+                        sleepBeforeRetry(attempt, instructionId);
+                    } catch (RuntimeException retryException) {
+                        e.addSuppressed(retryException);
+                        return recordTerminalFailure(errors, accountTransferDTO, instructionId, attempt, e);
+                    }
+                    continue;
                 }
-            });
-            transferCompleted = true;
-        } catch (final PlatformApiDataValidationException e) {
-            errors.add(new Exception("Validation exception while transfering funds for standing Instruction id" + instructionId + " from "
-                    + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId(), e));
-            errorLog.append("Validation exception while trasfering funds ").append(e.getDefaultUserMessage());
-        } catch (final InsufficientAccountBalanceException e) {
-            errors.add(new Exception("InsufficientAccountBalance Exception while trasfering funds for standing Instruction id"
-                    + instructionId + " from " + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId(), e));
-            errorLog.append("InsufficientAccountBalance Exception ");
-        } catch (final AbstractPlatformServiceUnavailableException e) {
-            errors.add(new Exception("Platform exception while trasfering funds for standing Instruction id" + instructionId + " from "
-                    + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId(), e));
-            errorLog.append("Platform exception while trasfering funds ").append(e.getDefaultUserMessage());
-        } catch (Exception e) {
-            errors.add(new Exception("Unhandled System Exception while trasfering funds for standing Instruction id" + instructionId
-                    + " from " + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId(), e));
-            errorLog.append("Exception while trasfering funds ").append(e.getMessage());
+                return recordTerminalFailure(errors, accountTransferDTO, instructionId, attempt, e);
+            }
         }
+        return false;
+    }
 
-        logTransferHistory(instructionId, accountTransferDTO.getTransactionAmount(), transferCompleted, errorLog.toString());
-        return transferCompleted;
+    void sleepBeforeRetry(int attempt, Long instructionId) {
+        try {
+            Thread.sleep(calculateRetryDelayMillis(attempt));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while retrying standing instruction " + instructionId, e);
+        }
+    }
+
+    private long calculateRetryDelayMillis(int attempt) {
+        return attempt * 1000L;
+    }
+
+    private boolean recordTerminalFailure(final List<Throwable> errors, final AccountTransferDTO accountTransferDTO,
+            final Long instructionId, final int attempts, final Exception cause) {
+        Exception transferFailure = wrapTransferException(accountTransferDTO, instructionId, attempts, cause);
+        errors.add(transferFailure);
+
+        try {
+            executeInNewTransaction(
+                    () -> logTransferHistory(instructionId, accountTransferDTO.getTransactionAmount(), false, buildErrorLog(cause)));
+        } catch (RuntimeException historyFailure) {
+            transferFailure.addSuppressed(historyFailure);
+            LOG.error("Failed to persist standing instruction failure history for {}", instructionId, historyFailure);
+        }
+        return false;
+    }
+
+    private Exception wrapTransferException(final AccountTransferDTO accountTransferDTO, final Long instructionId, final int attempts,
+            final Exception cause) {
+        String attemptSuffix = attempts > 1 ? " after " + attempts + " attempts" : "";
+        if (cause instanceof PlatformApiDataValidationException e) {
+            return new Exception("Validation exception while transfering funds for standing Instruction id" + instructionId + " from "
+                    + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId() + attemptSuffix, e);
+        } else if (cause instanceof InsufficientAccountBalanceException e) {
+            return new Exception("InsufficientAccountBalance Exception while trasfering funds for standing Instruction id" + instructionId
+                    + " from " + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId() + attemptSuffix, e);
+        } else if (cause instanceof AbstractPlatformServiceUnavailableException e) {
+            return new Exception("Platform exception while trasfering funds for standing Instruction id" + instructionId + " from "
+                    + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId() + attemptSuffix, e);
+        }
+        return new Exception("Unhandled System Exception while trasfering funds for standing Instruction id" + instructionId + " from "
+                + accountTransferDTO.getFromAccountId() + " to " + accountTransferDTO.getToAccountId() + attemptSuffix, cause);
+    }
+
+    private String buildErrorLog(final Exception cause) {
+        StringBuilder errorLog = new StringBuilder();
+        if (cause instanceof PlatformApiDataValidationException e) {
+            errorLog.append("Validation exception while trasfering funds ").append(e.getDefaultUserMessage());
+        } else if (cause instanceof InsufficientAccountBalanceException) {
+            errorLog.append("InsufficientAccountBalance Exception ");
+        } else if (cause instanceof AbstractPlatformServiceUnavailableException e) {
+            errorLog.append("Platform exception while trasfering funds ").append(e.getDefaultUserMessage());
+        } else {
+            errorLog.append("Exception while trasfering funds ").append(cause.getMessage());
+        }
+        if (errorLog.length() > MAX_ERROR_LOG_LENGTH) {
+            return errorLog.substring(0, MAX_ERROR_LOG_LENGTH);
+        }
+        return errorLog.toString();
+    }
+
+    private boolean isRetryableOptimisticLock(final Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof OptimisticLockException || current instanceof OptimisticLockingFailureException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private void executeInNewTransaction(final Runnable action) {
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+
+            @Override
+            protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
+                action.run();
+            }
+        });
     }
 
     private void updateLastRunDate(LocalDate transactionDate, Long instructionId) {
@@ -188,15 +263,9 @@ public class MnzlExecuteStandingInstructionsTasklet extends ExecuteStandingInstr
     }
 
     private void logTransferHistory(Long instructionId, BigDecimal amount, boolean success, String errorLog) {
-        StringBuilder updateQuery = new StringBuilder(
-                "INSERT INTO m_account_transfer_standing_instructions_history (standing_instruction_id, " + sqlGenerator.escape("status")
-                        + ", amount,execution_time, error_log) VALUES (");
-        updateQuery.append(instructionId).append(",");
-        updateQuery.append(success ? "'success'" : "'failed'").append(",");
-        updateQuery.append(amount.doubleValue());
-        updateQuery.append(", now(),");
-        updateQuery.append("'").append(errorLog).append("')");
-        jdbcTemplate.update(updateQuery.toString());
+        String updateQuery = "INSERT INTO m_account_transfer_standing_instructions_history (standing_instruction_id, "
+                + sqlGenerator.escape("status") + ", amount, execution_time, error_log) VALUES (?, ?, ?, now(), ?)";
+        jdbcTemplate.update(updateQuery, instructionId, success ? "success" : "failed", amount, errorLog);
     }
 
     @Override

--- a/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlExecuteStandingInstructionsTaskletTest.java
+++ b/custom/mnzl/loan/job/src/test/java/co/mnzl/fineract/custom/loan/job/MnzlExecuteStandingInstructionsTaskletTest.java
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.OptimisticLockException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.jobs.exception.TruncatedJobExecutionException;
+import org.apache.fineract.portfolio.account.PortfolioAccountType;
+import org.apache.fineract.portfolio.account.data.AccountTransferDTO;
+import org.apache.fineract.portfolio.account.data.PortfolioAccountData;
+import org.apache.fineract.portfolio.account.data.StandingInstructionData;
+import org.apache.fineract.portfolio.account.domain.AccountTransferRecurrenceType;
+import org.apache.fineract.portfolio.account.domain.AccountTransferType;
+import org.apache.fineract.portfolio.account.domain.StandingInstructionStatus;
+import org.apache.fineract.portfolio.account.domain.StandingInstructionType;
+import org.apache.fineract.portfolio.account.service.AccountTransfersWritePlatformService;
+import org.apache.fineract.portfolio.account.service.StandingInstructionReadPlatformService;
+import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.ScheduledDateGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class MnzlExecuteStandingInstructionsTaskletTest {
+
+    private static final String UPDATE_LAST_RUN_DATE_QUERY = "UPDATE m_account_transfer_standing_instructions SET last_run_date = ? where id = ?";
+
+    @Mock
+    private StandingInstructionReadPlatformService standingInstructionReadPlatformService;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private DatabaseSpecificSQLGenerator sqlGenerator;
+
+    @Mock
+    private AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @Mock
+    private ScheduledDateGenerator scheduledDateGenerator;
+
+    @Mock
+    private StepContribution stepContribution;
+
+    @Mock
+    private ChunkContext chunkContext;
+
+    @Mock
+    private TransactionStatus transactionStatus;
+
+    @Test
+    void executeRetriesOptimisticLockFailuresAndCompletesSuccessfully() throws Exception {
+        final LocalDate businessDate = LocalDate.of(2026, 3, 15);
+        final BigDecimal amount = new BigDecimal("123.45");
+        final StandingInstructionData instruction = standingInstruction(9794L, amount);
+        when(standingInstructionReadPlatformService.retrieveAll(StandingInstructionStatus.ACTIVE.getValue()))
+                .thenReturn(java.util.List.of(instruction));
+        when(scheduledDateGenerator.isDateFallsInSchedule(any(PeriodFrequencyType.class), anyInt(), any(LocalDate.class), eq(businessDate)))
+                .thenReturn(true);
+        when(sqlGenerator.escape("status")).thenReturn("status");
+        when(transactionTemplate.execute(any()))
+                .thenAnswer(invocation -> invocation.<TransactionCallback<Object>>getArgument(0).doInTransaction(transactionStatus));
+        doThrow(new OptimisticLockException("Loan 19543 changed during COB")).doReturn(29363L).when(accountTransfersWritePlatformService)
+                .transferFunds(any(AccountTransferDTO.class));
+
+        final MnzlExecuteStandingInstructionsTasklet underTest = spy(
+                new MnzlExecuteStandingInstructionsTasklet(standingInstructionReadPlatformService, jdbcTemplate, sqlGenerator,
+                        accountTransfersWritePlatformService, transactionTemplate, scheduledDateGenerator));
+        doNothing().when(underTest).sleepBeforeRetry(anyInt(), eq(9794L));
+
+        try (MockedStatic<DateUtils> mockedDateUtils = org.mockito.Mockito.mockStatic(DateUtils.class)) {
+            mockedDateUtils.when(DateUtils::getBusinessLocalDate).thenReturn(businessDate);
+
+            RepeatStatus result = underTest.execute(stepContribution, chunkContext);
+
+            assertEquals(RepeatStatus.FINISHED, result);
+        }
+
+        verify(underTest).sleepBeforeRetry(1, 9794L);
+        verify(accountTransfersWritePlatformService, times(2)).transferFunds(any(AccountTransferDTO.class));
+        verify(jdbcTemplate).update(UPDATE_LAST_RUN_DATE_QUERY, businessDate, 9794L);
+        verify(jdbcTemplate).update(startsWith("INSERT INTO m_account_transfer_standing_instructions_history"), eq(9794L), eq("success"),
+                eq(amount), eq(""));
+        verify(jdbcTemplate, never()).update(startsWith("INSERT INTO m_account_transfer_standing_instructions_history"), eq(9794L),
+                eq("failed"), eq(amount), any(String.class));
+    }
+
+    @Test
+    void executeRecordsFailedHistoryInNewTransactionAndTruncatesErrorLog() {
+        final LocalDate businessDate = LocalDate.of(2026, 3, 15);
+        final BigDecimal amount = new BigDecimal("42990.62");
+        final StandingInstructionData instruction = standingInstruction(9794L, amount);
+        final String longMessage = "x".repeat(600);
+        when(standingInstructionReadPlatformService.retrieveAll(StandingInstructionStatus.ACTIVE.getValue()))
+                .thenReturn(java.util.List.of(instruction));
+        when(scheduledDateGenerator.isDateFallsInSchedule(any(PeriodFrequencyType.class), anyInt(), any(LocalDate.class), eq(businessDate)))
+                .thenReturn(true);
+        when(sqlGenerator.escape("status")).thenReturn("status");
+        when(transactionTemplate.execute(any()))
+                .thenAnswer(invocation -> invocation.<TransactionCallback<Object>>getArgument(0).doInTransaction(transactionStatus));
+        doThrow(new IllegalStateException(longMessage)).when(accountTransfersWritePlatformService)
+                .transferFunds(any(AccountTransferDTO.class));
+
+        final MnzlExecuteStandingInstructionsTasklet underTest = new MnzlExecuteStandingInstructionsTasklet(
+                standingInstructionReadPlatformService, jdbcTemplate, sqlGenerator, accountTransfersWritePlatformService,
+                transactionTemplate, scheduledDateGenerator);
+
+        try (MockedStatic<DateUtils> mockedDateUtils = org.mockito.Mockito.mockStatic(DateUtils.class)) {
+            mockedDateUtils.when(DateUtils::getBusinessLocalDate).thenReturn(businessDate);
+
+            assertThatThrownBy(() -> underTest.execute(stepContribution, chunkContext)).isInstanceOf(TruncatedJobExecutionException.class);
+        }
+
+        final ArgumentCaptor<String> errorLogCaptor = ArgumentCaptor.forClass(String.class);
+        verify(accountTransfersWritePlatformService).transferFunds(any(AccountTransferDTO.class));
+        verify(jdbcTemplate, never()).update(eq(UPDATE_LAST_RUN_DATE_QUERY), any(LocalDate.class), any(Long.class));
+        verify(jdbcTemplate).update(startsWith("INSERT INTO m_account_transfer_standing_instructions_history"), eq(9794L), eq("failed"),
+                eq(amount), errorLogCaptor.capture());
+        verify(transactionTemplate, times(2)).execute(any());
+        assertThat(errorLogCaptor.getValue()).hasSize(500).startsWith("Exception while trasfering funds ");
+    }
+
+    private StandingInstructionData standingInstruction(Long id, BigDecimal amount) {
+        return StandingInstructionData.instance(id, 29363L, "To loan 000019543 from savings 000051352", null, null, null, null,
+                enumOption(PortfolioAccountType.SAVINGS.getValue().longValue(), "accountType.savings", "Savings"),
+                PortfolioAccountData.lookup(51352L, "000051352"),
+                enumOption(PortfolioAccountType.LOAN.getValue().longValue(), "accountType.loan", "Loan"),
+                PortfolioAccountData.lookup(19543L, "000019543"),
+                enumOption((long) AccountTransferType.LOAN_REPAYMENT.getValue(), "accountTransferType.loan.repayment", "Loan repayment"),
+                enumOption(3L, "standingInstructionPriority.medium", "Medium"),
+                enumOption((long) StandingInstructionType.FIXED.getValue(), "standingInstructionType.fixed", "Fixed"),
+                enumOption((long) StandingInstructionStatus.ACTIVE.getValue(), "standingInstructionStatus.active", "Active"), amount,
+                LocalDate.of(2026, 2, 25), null,
+                enumOption((long) AccountTransferRecurrenceType.PERIODIC.getValue(), "accountTransferRecurrenceType.periodic", "Periodic"),
+                enumOption((long) PeriodFrequencyType.DAYS.getValue(), "periodFrequencyType.days", "Days"), 1, null);
+    }
+
+    private EnumOptionData enumOption(Long id, String code, String description) {
+        return new EnumOptionData(id, code, description);
+    }
+}


### PR DESCRIPTION
## Summary
- retry standing instruction transfers when the underlying loan update fails with an optimistic lock
- keep successful transfer bookkeeping in the same REQUIRES_NEW transaction as the transfer
- persist failed standing-instruction history in its own REQUIRES_NEW transaction and truncate error_log to the table limit

## Context
The staging `Execute Standing Instruction` cron failed when a savings-to-loan transfer raced another loan updater during the 22:00 UTC scheduler wave. The same standing instruction succeeded on manual rerun, so the failure was transient.

## Testing
- `./gradlew :custom:mnzl:loan:job:test`
