### PR TITLE
Preserve periodic loan charge recurrence metadata

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
@@ -711,6 +711,6 @@ public class LoanAccountData {
         return LoanChargeData.newLoanChargeDetails(chargeData.getId(), chargeData.getName(), chargeData.getCurrency(),
                 chargeData.getAmount(), percentage, chargeData.getChargeTimeType(), chargeData.getChargeCalculationType(),
                 chargeData.isPenalty(), chargeData.getChargePaymentMode(), chargeData.getMinCap(), chargeData.getMaxCap(),
-                ExternalId.empty());
+                chargeData.getFeeInterval(), chargeData.getFeeFrequency(), ExternalId.empty());
     }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanChargeData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanChargeData.java
@@ -84,6 +84,10 @@ public class LoanChargeData {
 
     private final BigDecimal maxCap;
 
+    private final Integer feeInterval;
+
+    private final EnumOptionData feeFrequency;
+
     private final List<LoanInstallmentChargeData> installmentChargeData;
 
     private BigDecimal amountAccrued;
@@ -96,7 +100,7 @@ public class LoanChargeData {
 
     public static LoanChargeData template(final List<ChargeData> chargeOptions) {
         return new LoanChargeData(null, null, null, null, null, null, null, null, chargeOptions, false, null, false, false, null,
-                ExternalId.empty(), null, null, null, null, ExternalId.empty());
+                ExternalId.empty(), null, null, null, null, null, null, ExternalId.empty());
     }
 
     /**
@@ -105,9 +109,11 @@ public class LoanChargeData {
     public static LoanChargeData newLoanChargeDetails(final Long chargeId, final String name, final CurrencyData currency,
             final BigDecimal amount, final BigDecimal percentage, final EnumOptionData chargeTimeType,
             final EnumOptionData chargeCalculationType, final boolean penalty, final EnumOptionData chargePaymentMode,
-            final BigDecimal minCap, final BigDecimal maxCap, final ExternalId externalId) {
+            final BigDecimal minCap, final BigDecimal maxCap, final Integer feeInterval, final EnumOptionData feeFrequency,
+            final ExternalId externalId) {
         return new LoanChargeData(null, chargeId, name, currency, amount, percentage, chargeTimeType, chargeCalculationType, null, penalty,
-                chargePaymentMode, false, false, null, ExternalId.empty(), minCap, maxCap, null, null, externalId);
+                chargePaymentMode, false, false, null, ExternalId.empty(), minCap, maxCap, feeInterval, feeFrequency, null, null,
+                externalId);
     }
 
     public LoanChargeData(final Long id, final Long chargeId, final String name, final CurrencyData currency, final BigDecimal amount,
@@ -116,7 +122,8 @@ public class LoanChargeData {
             final LocalDate dueDate, final EnumOptionData chargeCalculationType, final BigDecimal percentage,
             final BigDecimal amountPercentageAppliedTo, final boolean penalty, final EnumOptionData chargePaymentMode, final boolean paid,
             final boolean waived, final Long loanId, final ExternalId externalLoanId, final BigDecimal minCap, final BigDecimal maxCap,
-            final BigDecimal amountOrPercentage, List<LoanInstallmentChargeData> installmentChargeData, final ExternalId externalId) {
+            final Integer feeInterval, final EnumOptionData feeFrequency, final BigDecimal amountOrPercentage,
+            List<LoanInstallmentChargeData> installmentChargeData, final ExternalId externalId) {
         this.id = id;
         this.chargeId = chargeId;
         this.name = name;
@@ -138,6 +145,8 @@ public class LoanChargeData {
         this.waived = waived;
         this.minCap = minCap;
         this.maxCap = maxCap;
+        this.feeInterval = feeInterval;
+        this.feeFrequency = feeFrequency;
         if (amountOrPercentage == null) {
             if (chargeCalculationType != null && chargeCalculationType.getId().intValue() > 1) {
                 this.amountOrPercentage = this.percentage;
@@ -162,7 +171,8 @@ public class LoanChargeData {
             final BigDecimal percentage, final EnumOptionData chargeTimeType, final EnumOptionData chargeCalculationType,
             final List<ChargeData> chargeOptions, final boolean penalty, final EnumOptionData chargePaymentMode, final boolean paid,
             final boolean waived, final Long loanId, final ExternalId externalLoanId, final BigDecimal minCap, final BigDecimal maxCap,
-            final BigDecimal amountOrPercentage, List<LoanInstallmentChargeData> installmentChargeData, final ExternalId externalId) {
+            final Integer feeInterval, final EnumOptionData feeFrequency, final BigDecimal amountOrPercentage,
+            List<LoanInstallmentChargeData> installmentChargeData, final ExternalId externalId) {
         this.id = id;
         this.chargeId = chargeId;
         this.name = name;
@@ -199,6 +209,8 @@ public class LoanChargeData {
         this.externalLoanId = externalLoanId;
         this.minCap = minCap;
         this.maxCap = maxCap;
+        this.feeInterval = feeInterval;
+        this.feeFrequency = feeFrequency;
         this.installmentChargeData = installmentChargeData;
         this.amountAccrued = null;
         this.amountUnrecognized = null;
@@ -233,6 +245,8 @@ public class LoanChargeData {
         this.loanId = loanId;
         this.minCap = null;
         this.maxCap = null;
+        this.feeInterval = null;
+        this.feeFrequency = null;
         this.installmentChargeData = installmentChargeData;
         this.amountAccrued = null;
         this.amountUnrecognized = null;
@@ -269,6 +283,8 @@ public class LoanChargeData {
         this.externalLoanId = ExternalId.empty();
         this.minCap = null;
         this.maxCap = null;
+        this.feeInterval = null;
+        this.feeFrequency = null;
         this.installmentChargeData = null;
         this.amountAccrued = amountAccrued;
         this.amountUnrecognized = null;
@@ -302,6 +318,8 @@ public class LoanChargeData {
         this.externalLoanId = ExternalId.empty();
         this.minCap = null;
         this.maxCap = null;
+        this.feeInterval = chargeData.feeInterval;
+        this.feeFrequency = chargeData.feeFrequency;
         this.installmentChargeData = null;
         this.amountAccrued = chargeData.amountAccrued;
         this.amountUnrecognized = amountUnrecognized;
@@ -335,6 +353,8 @@ public class LoanChargeData {
         this.chargePayable = chargeData.chargePayable;
         this.loanId = chargeData.loanId;
         this.externalLoanId = chargeData.externalLoanId;
+        this.feeInterval = chargeData.feeInterval;
+        this.feeFrequency = chargeData.feeFrequency;
         this.installmentChargeData = installmentChargeData;
         this.amountAccrued = chargeData.amountAccrued;
         this.amountUnrecognized = chargeData.amountUnrecognized;
@@ -369,6 +389,8 @@ public class LoanChargeData {
         this.externalLoanId = ExternalId.empty();
         this.minCap = null;
         this.maxCap = null;
+        this.feeInterval = null;
+        this.feeFrequency = null;
         this.installmentChargeData = null;
         this.amountAccrued = null;
         this.amountUnrecognized = null;
@@ -402,6 +424,8 @@ public class LoanChargeData {
         this.externalLoanId = ExternalId.empty();
         this.minCap = null;
         this.maxCap = null;
+        this.feeInterval = null;
+        this.feeFrequency = null;
         this.installmentChargeData = null;
         this.amountAccrued = null;
         this.amountUnrecognized = null;

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCharge.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCharge.java
@@ -47,6 +47,7 @@ import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.charge.data.ChargeData;
 import org.apache.fineract.portfolio.charge.domain.Charge;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
@@ -714,15 +715,17 @@ public class LoanCharge extends AbstractAuditableWithUTCDateTimeCustom<Long> {
         EnumOptionData chargeCalculationTypeData = ChargeCalculationOptionDataLookup.optionData(this.chargeCalculation);
         EnumOptionData chargePaymentModeData = new EnumOptionData((long) getChargePaymentMode().ordinal(), getChargePaymentMode().getCode(),
                 String.valueOf(getChargePaymentMode().getValue()));
+        ChargeData chargeData = getCharge().toData();
         List<LoanInstallmentChargeData> loanInstallmentChargeDataList = installmentCharges().stream().map(LoanInstallmentCharge::toData)
                 .toList();
 
         return LoanChargeData.builder().id(getId()).chargeId(getCharge().getId()).name(getCharge().getName())
-                .currency(getCharge().toData().getCurrency()).amount(amount).amountPaid(amountPaid).amountWaived(amountWaived)
+                .currency(chargeData.getCurrency()).amount(amount).amountPaid(amountPaid).amountWaived(amountWaived)
                 .amountWrittenOff(amountWrittenOff).amountOutstanding(amountOutstanding).chargeTimeType(chargeTimeTypeData)
                 .submittedOnDate(submittedOnDate).dueDate(dueDate).chargeCalculationType(chargeCalculationTypeData).percentage(percentage)
                 .amountPercentageAppliedTo(amountPercentageAppliedTo).amountOrPercentage(amountOrPercentage).penalty(penaltyCharge)
                 .chargePaymentMode(chargePaymentModeData).paid(paid).waived(waived).loanId(loan.getId()).minCap(minCap).maxCap(maxCap)
+                .feeInterval(chargeData.getFeeInterval()).feeFrequency(chargeData.getFeeFrequency())
                 .installmentChargeData(loanInstallmentChargeDataList).externalId(externalId).build();
     }
 

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/data/LoanChargeDataTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/data/LoanChargeDataTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
+import org.apache.fineract.organisation.monetary.data.CurrencyData;
+import org.apache.fineract.portfolio.charge.data.ChargeData;
+import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.junit.jupiter.api.Test;
+
+class LoanChargeDataTest {
+
+    @Test
+    void toLoanChargeDataKeepsRecurringChargeMetadata() {
+        EnumOptionData feeFrequency = new EnumOptionData(3L, "feeFrequencyperiodFrequencyType.months", "Months");
+        ChargeData chargeData = ChargeData.builder().id(9L).name("Insurance")
+                .currency(new CurrencyData("USD", "US Dollar", 2, 0, "$", "USD")).amount(new BigDecimal("10.00"))
+                .chargeTimeType(new EnumOptionData((long) ChargeTimeType.LOAN_PERIODIC.getValue(), ChargeTimeType.LOAN_PERIODIC.getCode(),
+                        "Periodic Loan Charge"))
+                .chargeCalculationType(new EnumOptionData(1L, "chargeCalculationType.flat", "Flat"))
+                .chargePaymentMode(
+                        new EnumOptionData((long) ChargePaymentMode.REGULAR.getValue(), ChargePaymentMode.REGULAR.getCode(), "Regular"))
+                .feeInterval(2).feeFrequency(feeFrequency).build();
+
+        LoanChargeData result = LoanAccountData.toLoanChargeData(chargeData);
+
+        assertEquals(2, result.getFeeInterval());
+        assertEquals(feeFrequency, result.getFeeFrequency());
+    }
+
+    @Test
+    void copyConstructorPreservesRecurringChargeMetadata() {
+        EnumOptionData feeFrequency = new EnumOptionData(4L, "feeFrequencyperiodFrequencyType.years", "Years");
+        LoanChargeData original = LoanChargeData.builder().id(1L).chargeId(9L).feeInterval(1).feeFrequency(feeFrequency)
+                .externalId(ExternalId.empty()).externalLoanId(ExternalId.empty()).build();
+
+        LoanChargeData copied = new LoanChargeData(original, List.of());
+
+        assertEquals(original.getFeeInterval(), copied.getFeeInterval());
+        assertEquals(original.getFeeFrequency(), copied.getFeeFrequency());
+    }
+}

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/LoanChargeTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/LoanChargeTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
+import org.apache.fineract.organisation.monetary.data.CurrencyData;
+import org.apache.fineract.portfolio.charge.data.ChargeData;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.loanaccount.data.LoanChargeData;
+import org.junit.jupiter.api.Test;
+
+class LoanChargeTest {
+
+    @Test
+    void toDataIncludesRecurringChargeMetadata() {
+        EnumOptionData feeFrequency = new EnumOptionData(4L, "feeFrequencyperiodFrequencyType.years", "Years");
+        Charge charge = mock(Charge.class);
+        when(charge.getId()).thenReturn(7L);
+        when(charge.getName()).thenReturn("Insurance");
+        when(charge.toData()).thenReturn(ChargeData.builder().currency(new CurrencyData("USD", "US Dollar", 2, 0, "$", "USD"))
+                .feeInterval(1).feeFrequency(feeFrequency).build());
+
+        Loan loan = mock(Loan.class);
+        when(loan.getId()).thenReturn(5L);
+
+        LoanCharge loanCharge = new LoanCharge();
+        loanCharge.setLoan(loan);
+        loanCharge.setCharge(charge);
+        loanCharge.setAmount(new BigDecimal("10.00"));
+        loanCharge.setAmountOutstanding(new BigDecimal("10.00"));
+        loanCharge.setChargeTime(ChargeTimeType.LOAN_PERIODIC.getValue());
+        loanCharge.setChargeCalculation(ChargeCalculationType.FLAT.getValue());
+        loanCharge.setDueDate(LocalDate.of(2024, 2, 1));
+        loanCharge.setChargePaymentMode(ChargePaymentMode.REGULAR.getValue());
+        loanCharge.setExternalId(ExternalId.empty());
+
+        LoanChargeData result = loanCharge.toData();
+
+        assertEquals(1, result.getFeeInterval());
+        assertEquals(feeFrequency, result.getFeeFrequency());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResource.java
@@ -82,7 +82,7 @@ public class LoanChargesApiResource {
     private static final Set<String> RESPONSE_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList("id", "chargeId", "name", "penalty", "chargeTimeType", "dueAsOfDate", "chargeCalculationType", "percentage",
                     "amountPercentageAppliedTo", "currency", "amountWaived", "amountWrittenOff", "amountOutstanding", "amountOrPercentage",
-                    "amount", "amountPaid", "chargeOptions", "installmentChargeData", "externalId"));
+                    "amount", "amountPaid", "chargeOptions", "feeInterval", "feeFrequency", "installmentChargeData", "externalId"));
     private static final String RESOURCE_NAME_FOR_PERMISSIONS = "LOAN";
     private final PlatformSecurityContext context;
     private final ChargeReadPlatformService chargeReadPlatformService;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanChargeReadPlatformServiceImpl.java
@@ -37,6 +37,7 @@ import org.apache.fineract.portfolio.charge.exception.LoanChargeNotFoundExceptio
 import org.apache.fineract.portfolio.charge.service.ChargeCalculationOptionDataService;
 import org.apache.fineract.portfolio.charge.service.ChargeDropdownReadPlatformService;
 import org.apache.fineract.portfolio.charge.service.ChargeEnumerations;
+import org.apache.fineract.portfolio.common.service.CommonEnumerations;
 import org.apache.fineract.portfolio.common.service.DropdownReadPlatformService;
 import org.apache.fineract.portfolio.loanaccount.data.LoanChargeData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanChargePaidByData;
@@ -73,7 +74,8 @@ public class LoanChargeReadPlatformServiceImpl implements LoanChargeReadPlatform
                     + "lc.calculation_percentage as percentageOf, lc.calculation_on_amount as amountPercentageAppliedTo, " //
                     + "lc.charge_time_enum as chargeTime, lc.is_penalty as penalty, " //
                     + "lc.due_for_collection_as_of_date as dueAsOfDate, lc.charge_calculation_enum as chargeCalculation, " //
-                    + "lc.charge_payment_mode_enum as chargePaymentMode, lc.is_paid_derived as paid, lc.waived as waived, " //
+                    + "lc.charge_payment_mode_enum as chargePaymentMode, c.fee_interval as feeInterval, c.fee_frequency as feeFrequency, "
+                    + "lc.is_paid_derived as paid, lc.waived as waived, " //
                     + "lc.min_cap as minCap, lc.max_cap as maxCap, lc.charge_amount_or_percentage as amountOrPercentage, " //
                     + "lc.loan_id as loanId, c.currency_code as currencyCode, oc.name as currencyName, " //
                     + "date(coalesce(dd.disbursedon_date,dd.expected_disburse_date)) as disbursementDate, " //
@@ -120,6 +122,12 @@ public class LoanChargeReadPlatformServiceImpl implements LoanChargeReadPlatform
 
             final int chargePaymentMode = rs.getInt("chargePaymentMode");
             final EnumOptionData paymentMode = ChargeEnumerations.chargePaymentMode(chargePaymentMode);
+            final Integer feeInterval = JdbcSupport.getInteger(rs, "feeInterval");
+            EnumOptionData feeFrequencyType = null;
+            final Integer feeFrequency = JdbcSupport.getInteger(rs, "feeFrequency");
+            if (feeFrequency != null) {
+                feeFrequencyType = CommonEnumerations.termFrequencyType(feeFrequency, "feeFrequency");
+            }
             final boolean paid = rs.getBoolean("paid");
             final boolean waived = rs.getBoolean("waived");
             final BigDecimal minCap = rs.getBigDecimal("minCap");
@@ -138,7 +146,8 @@ public class LoanChargeReadPlatformServiceImpl implements LoanChargeReadPlatform
 
             return new LoanChargeData(id, chargeId, name, currency, amount, amountPaid, amountWaived, amountWrittenOff, amountOutstanding,
                     chargeTimeType, submittedOnDate, dueAsOfDate, chargeCalculationType, percentageOf, amountPercentageAppliedTo, penalty,
-                    paymentMode, paid, waived, loanId, externalLoanId, minCap, maxCap, amountOrPercentage, null, externalId);
+                    paymentMode, paid, waived, loanId, externalLoanId, minCap, maxCap, feeInterval, feeFrequencyType, amountOrPercentage,
+                    null, externalId);
         }
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanPeriodicChargeIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanPeriodicChargeIntegrationTest.java
@@ -21,6 +21,7 @@ package org.apache.fineract.integrationtests;
 import static org.apache.fineract.accounting.common.AccountingConstants.FinancialActivity.LIABILITY_TRANSFER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.restassured.path.json.JsonPath;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -76,6 +77,31 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
 
             schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
             assertEquals(1, loanTransactionHelper.getLoanCharges(context.loanId()).size());
+        });
+    }
+
+    @Test
+    public void testPeriodicLoanChargeResponsesIncludeRecurrenceMetadata() {
+        AtomicReference<PeriodicLoanContext> contextRef = new AtomicReference<>();
+
+        runAt(LOAN_DISBURSEMENT_DATE, () -> contextRef.set(createPeriodicLoan(6)));
+
+        PeriodicLoanContext context = contextRef.get();
+        JsonPath templateJson = JsonPath.from(Utils.performServerGet(requestSpec, responseSpec,
+                "/fineract-provider/api/v1/loans/template?templateType=individual&clientId=" + context.clientId() + "&productId="
+                        + context.loanProductId() + "&" + Utils.TENANT_IDENTIFIER));
+        assertEquals(1, templateJson.getList("charges").size());
+        assertEquals(1, templateJson.getInt("charges[0].feeInterval"));
+        assertEquals(ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS, templateJson.getInt("charges[0].feeFrequency.id"));
+
+        runAt(formatDate(context.firstRepaymentDate()), () -> {
+            schedulerJobHelper.executeAndAwaitJobByShortName(PERIODIC_JOB_SHORT_NAME);
+
+            JsonPath loanChargesJson = JsonPath.from(Utils.performServerGet(requestSpec, responseSpec,
+                    "/fineract-provider/api/v1/loans/" + context.loanId() + "/charges?" + Utils.TENANT_IDENTIFIER));
+            assertEquals(1, loanChargesJson.getList("$").size());
+            assertEquals(1, loanChargesJson.getInt("[0].feeInterval"));
+            assertEquals(ChargesHelper.CHARGE_FEE_FREQUENCY_YEARS, loanChargesJson.getInt("[0].feeFrequency.id"));
         });
     }
 
@@ -169,7 +195,7 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
 
         GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
         LocalDate firstRepaymentDate = repaymentPeriod(loanDetails, 1).getDueDate();
-        return new PeriodicLoanContext(loanId, firstRepaymentDate, null);
+        return new PeriodicLoanContext(clientId, loanProductId, loanId, firstRepaymentDate, null);
     }
 
     private PeriodicLoanContext createPeriodicLoanWithLinkedSavings(final int numberOfRepayments) {
@@ -206,7 +232,7 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
 
         GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
         LocalDate firstRepaymentDate = repaymentPeriod(loanDetails, 1).getDueDate();
-        return new PeriodicLoanContext(loanId, firstRepaymentDate, savingsAccountId);
+        return new PeriodicLoanContext(clientId, loanProductId, loanId, firstRepaymentDate, savingsAccountId);
     }
 
     private Integer createSavingsAccountDailyPosting(final SavingsAccountHelper savingsAccountHelper, final Integer clientId,
@@ -257,6 +283,7 @@ public class LoanPeriodicChargeIntegrationTest extends BaseLoanIntegrationTest {
                 CommonConstants.RESPONSE_RESOURCE_ID);
     }
 
-    private record PeriodicLoanContext(Long loanId, LocalDate firstRepaymentDate, Integer savingsAccountId) {
+    private record PeriodicLoanContext(Long clientId, Long loanProductId, Long loanId, LocalDate firstRepaymentDate,
+            Integer savingsAccountId) {
     }
 }


### PR DESCRIPTION
## Summary
- preserve `feeInterval` and `feeFrequency` when loan product charges are converted into `LoanChargeData` for `/loans/template`
- include the same recurrence metadata in loan charge read responses and `LoanCharge.toData()` so materialized periodic charges stay consistent across APIs
- extend periodic loan charge coverage with DTO/domain unit tests and a REST integration check for both template and loan charge endpoints

## Verification
- `./gradlew :fineract-loan:test --tests 'org.apache.fineract.portfolio.loanaccount.data.LoanChargeDataTest' --tests 'org.apache.fineract.portfolio.loanaccount.domain.LoanChargeTest' :fineract-provider:compileJava --console=plain`
- `./gradlew :integration-tests:test -PcargoDisabled --tests 'org.apache.fineract.integrationtests.LoanPeriodicChargeIntegrationTest' --console=plain`
- `./gradlew :fineract-loan:spotlessCheck :fineract-provider:spotlessCheck :integration-tests:spotlessCheck --console=plain`

Integration result: all 4 `LoanPeriodicChargeIntegrationTest` cases passed, including the new recurrence-metadata response check.