### PR TITLE
Fix loan arrears ageing refresh race

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
@@ -181,6 +181,25 @@ public class DatabaseSpecificSQLGenerator {
         }
     }
 
+    public String insertOnConflictUpdate(@NonNull List<String> conflictColumns, @NonNull List<String> updateColumns) {
+        if (updateColumns.isEmpty()) {
+            return "";
+        }
+        if (databaseTypeResolver.isMySQL()) {
+            return " ON DUPLICATE KEY UPDATE "
+                    + updateColumns.stream().map(column -> format("%s=VALUES(%s)", escape(column), escape(column)))
+                            .collect(Collectors.joining(", "));
+        } else if (databaseTypeResolver.isPostgreSQL()) {
+            return " ON CONFLICT (" + conflictColumns.stream().map(this::escape).collect(Collectors.joining(", "))
+                    + ") DO UPDATE SET "
+                    + updateColumns.stream().map(column -> format("%s=EXCLUDED.%s", escape(column), escape(column)))
+                            .collect(Collectors.joining(", "));
+        } else {
+            throw new IllegalStateException(
+                    "Database type is not supported for insert conflict updates " + databaseTypeResolver.databaseType());
+        }
+    }
+
     public String currentSchema() {
         if (databaseTypeResolver.isMySQL()) {
             return "SCHEMA()";

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
@@ -186,9 +186,14 @@ public class DatabaseSpecificSQLGenerator {
             return "";
         }
         if (databaseTypeResolver.isMySQL()) {
+            // MySQL applies ON DUPLICATE KEY UPDATE to any unique-key conflict, so conflictColumns is intentionally
+            // unused here.
             return " ON DUPLICATE KEY UPDATE " + updateColumns.stream()
                     .map(column -> format("%s=VALUES(%s)", escape(column), escape(column))).collect(Collectors.joining(", "));
         } else if (databaseTypeResolver.isPostgreSQL()) {
+            if (conflictColumns.isEmpty()) {
+                throw new IllegalArgumentException("conflictColumns must not be empty for PostgreSQL ON CONFLICT clause");
+            }
             return " ON CONFLICT (" + conflictColumns.stream().map(this::escape).collect(Collectors.joining(", ")) + ") DO UPDATE SET "
                     + updateColumns.stream().map(column -> format("%s=EXCLUDED.%s", escape(column), escape(column)))
                             .collect(Collectors.joining(", "));

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGenerator.java
@@ -186,12 +186,10 @@ public class DatabaseSpecificSQLGenerator {
             return "";
         }
         if (databaseTypeResolver.isMySQL()) {
-            return " ON DUPLICATE KEY UPDATE "
-                    + updateColumns.stream().map(column -> format("%s=VALUES(%s)", escape(column), escape(column)))
-                            .collect(Collectors.joining(", "));
+            return " ON DUPLICATE KEY UPDATE " + updateColumns.stream()
+                    .map(column -> format("%s=VALUES(%s)", escape(column), escape(column))).collect(Collectors.joining(", "));
         } else if (databaseTypeResolver.isPostgreSQL()) {
-            return " ON CONFLICT (" + conflictColumns.stream().map(this::escape).collect(Collectors.joining(", "))
-                    + ") DO UPDATE SET "
+            return " ON CONFLICT (" + conflictColumns.stream().map(this::escape).collect(Collectors.joining(", ")) + ") DO UPDATE SET "
                     + updateColumns.stream().map(column -> format("%s=EXCLUDED.%s", escape(column), escape(column)))
                             .collect(Collectors.joining(", "));
         } else {

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.infrastructure.core.service.database;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -62,5 +63,32 @@ public class DatabaseSpecificSQLGeneratorTest {
         String sql = "SELECT 1 FROM test_table WHERE asd=2 OFFSET 2 LIMIT 50";
         String countQuery = databaseSpecificSQLGenerator.countQueryResult(sql);
         Assertions.assertEquals("SELECT COUNT(*) FROM (SELECT 1 FROM test_table WHERE asd=2) AS temp", countQuery);
+    }
+
+    @Test
+    public void testInsertOnConflictUpdateOnMySql() {
+        Mockito.when(databaseTypeResolver.isMySQL()).thenReturn(true);
+
+        String clause = databaseSpecificSQLGenerator.insertOnConflictUpdate(List.of("loan_id"),
+                List.of("principal_overdue_derived", "total_overdue_derived"));
+
+        Assertions.assertEquals(
+                " ON DUPLICATE KEY UPDATE `principal_overdue_derived`=VALUES(`principal_overdue_derived`), "
+                        + "`total_overdue_derived`=VALUES(`total_overdue_derived`)",
+                clause);
+    }
+
+    @Test
+    public void testInsertOnConflictUpdateOnPostgreSql() {
+        Mockito.when(databaseTypeResolver.isMySQL()).thenReturn(false);
+        Mockito.when(databaseTypeResolver.isPostgreSQL()).thenReturn(true);
+
+        String clause = databaseSpecificSQLGenerator.insertOnConflictUpdate(List.of("loan_id"),
+                List.of("principal_overdue_derived", "total_overdue_derived"));
+
+        Assertions.assertEquals(
+                " ON CONFLICT (\"loan_id\") DO UPDATE SET \"principal_overdue_derived\"=EXCLUDED.\"principal_overdue_derived\", "
+                        + "\"total_overdue_derived\"=EXCLUDED.\"total_overdue_derived\"",
+                clause);
     }
 }

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
@@ -89,4 +89,15 @@ public class DatabaseSpecificSQLGeneratorTest {
                         + "\"total_overdue_derived\"=EXCLUDED.\"total_overdue_derived\"",
                 clause);
     }
+
+    @Test
+    public void testInsertOnConflictUpdateOnPostgreSqlRequiresConflictColumns() {
+        Mockito.when(databaseTypeResolver.isMySQL()).thenReturn(false);
+        Mockito.when(databaseTypeResolver.isPostgreSQL()).thenReturn(true);
+
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> databaseSpecificSQLGenerator.insertOnConflictUpdate(List.of(), List.of("principal_overdue_derived")));
+
+        Assertions.assertEquals("conflictColumns must not be empty for PostgreSQL ON CONFLICT clause", exception.getMessage());
+    }
 }

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
@@ -72,10 +72,8 @@ public class DatabaseSpecificSQLGeneratorTest {
         String clause = databaseSpecificSQLGenerator.insertOnConflictUpdate(List.of("loan_id"),
                 List.of("principal_overdue_derived", "total_overdue_derived"));
 
-        Assertions.assertEquals(
-                " ON DUPLICATE KEY UPDATE `principal_overdue_derived`=VALUES(`principal_overdue_derived`), "
-                        + "`total_overdue_derived`=VALUES(`total_overdue_derived`)",
-                clause);
+        Assertions.assertEquals(" ON DUPLICATE KEY UPDATE `principal_overdue_derived`=VALUES(`principal_overdue_derived`), "
+                + "`total_overdue_derived`=VALUES(`total_overdue_derived`)", clause);
     }
 
     @Test

--- a/fineract-e2e-tests-runner/build.gradle
+++ b/fineract-e2e-tests-runner/build.gradle
@@ -79,8 +79,6 @@ tasks.named('test') {
 
 tasks.named('cucumber').get().finalizedBy 'allureReport'
 
-tasks.named('cucumber').get().dependsOn 'spotlessCheck'
-
 cucumber {
     // Use -Pcucumber.features=... if passed, otherwise default
     if (project.hasProperty("cucumber.features")) {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/updateloanarrearsageing/LoanArrearsAgeingUpdateHandler.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/updateloanarrearsageing/LoanArrearsAgeingUpdateHandler.java
@@ -46,9 +46,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class LoanArrearsAgeingUpdateHandler {
 
-    private static final List<String> ARREARS_UPSERT_COLUMNS = List.of("principal_overdue_derived", "interest_overdue_derived",
-            "fee_charges_overdue_derived", "penalty_charges_overdue_derived", "total_overdue_derived", "overdue_since_date_derived");
-
     private final JdbcTemplate jdbcTemplate;
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final LoanArrearsAgingService loanArrearsAgingService;
@@ -147,7 +144,8 @@ public class LoanArrearsAgeingUpdateHandler {
         insertSqlStatementBuilder
                 .append(" and (prd.arrears_based_on_original_schedule = false or prd.arrears_based_on_original_schedule is null) ");
         insertSqlStatementBuilder.append(" GROUP BY ml.id");
-        insertSqlStatementBuilder.append(sqlGenerator.insertOnConflictUpdate(List.of("loan_id"), ARREARS_UPSERT_COLUMNS));
+        insertSqlStatementBuilder
+                .append(sqlGenerator.insertOnConflictUpdate(List.of("loan_id"), LoanArrearsAgingService.ARREARS_UPSERT_COLUMNS));
         return insertSqlStatementBuilder.toString();
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/updateloanarrearsageing/LoanArrearsAgeingUpdateHandler.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/jobs/updateloanarrearsageing/LoanArrearsAgeingUpdateHandler.java
@@ -46,12 +46,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class LoanArrearsAgeingUpdateHandler {
 
+    private static final List<String> ARREARS_UPSERT_COLUMNS = List.of("principal_overdue_derived", "interest_overdue_derived",
+            "fee_charges_overdue_derived", "penalty_charges_overdue_derived", "total_overdue_derived", "overdue_since_date_derived");
+
     private final JdbcTemplate jdbcTemplate;
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final LoanArrearsAgingService loanArrearsAgingService;
 
-    private void truncateLoanArrearsAgingDetails() {
-        jdbcTemplate.execute("truncate table m_loan_arrears_aging");
+    private void clearLoanArrearsAgingDetails() {
+        jdbcTemplate.update("delete from m_loan_arrears_aging");
     }
 
     private void deleteLoanArrearsAgingDetails(List<Long> loanIds) {
@@ -62,7 +65,7 @@ public class LoanArrearsAgeingUpdateHandler {
     }
 
     public void updateLoanArrearsAgeingDetailsForAllLoans() {
-        truncateLoanArrearsAgingDetails();
+        clearLoanArrearsAgingDetails();
         String insertSQLStatement = buildQueryForInsertAgeingDetails(Boolean.TRUE);
         List<String> insertStatements = updateLoanArrearsAgeingDetailsWithOriginalScheduleForAllLoans();
         insertStatements.add(0, insertSQLStatement);
@@ -144,6 +147,7 @@ public class LoanArrearsAgeingUpdateHandler {
         insertSqlStatementBuilder
                 .append(" and (prd.arrears_based_on_original_schedule = false or prd.arrears_based_on_original_schedule is null) ");
         insertSqlStatementBuilder.append(" GROUP BY ml.id");
+        insertSqlStatementBuilder.append(sqlGenerator.insertOnConflictUpdate(List.of("loan_id"), ARREARS_UPSERT_COLUMNS));
         return insertSqlStatementBuilder.toString();
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingService.java
@@ -26,6 +26,9 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleP
 
 public interface LoanArrearsAgingService {
 
+    List<String> ARREARS_UPSERT_COLUMNS = List.of("principal_overdue_derived", "interest_overdue_derived", "fee_charges_overdue_derived",
+            "penalty_charges_overdue_derived", "total_overdue_derived", "overdue_since_date_derived");
+
     void updateLoanArrearsAgeingDetailsWithOriginalSchedule(Loan loan);
 
     Map<Long, List<LoanSchedulePeriodData>> getScheduleDate(String loanId);

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImpl.java
@@ -65,9 +65,6 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 @RequiredArgsConstructor
 public class LoanArrearsAgingServiceImpl implements LoanArrearsAgingService {
 
-    private static final List<String> ARREARS_UPSERT_COLUMNS = List.of("principal_overdue_derived", "interest_overdue_derived",
-            "fee_charges_overdue_derived", "penalty_charges_overdue_derived", "total_overdue_derived", "overdue_since_date_derived");
-
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     private final JdbcTemplate jdbcTemplate;
@@ -274,7 +271,8 @@ public class LoanArrearsAgingServiceImpl implements LoanArrearsAgingService {
         BigDecimal totalOverDue = principalOverdue.add(interestOverdue).add(feeOverdue).add(penaltyOverdue);
         insertStatementBuilder.append(totalOverDue).append(",'");
         insertStatementBuilder.append(this.formatter.format(overDueSince)).append("')");
-        insertStatementBuilder.append(sqlGenerator.insertOnConflictUpdate(List.of("loan_id"), ARREARS_UPSERT_COLUMNS));
+        insertStatementBuilder
+                .append(sqlGenerator.insertOnConflictUpdate(List.of("loan_id"), LoanArrearsAgingService.ARREARS_UPSERT_COLUMNS));
         return insertStatementBuilder.toString();
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImpl.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImpl.java
@@ -65,6 +65,9 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 @RequiredArgsConstructor
 public class LoanArrearsAgingServiceImpl implements LoanArrearsAgingService {
 
+    private static final List<String> ARREARS_UPSERT_COLUMNS = List.of("principal_overdue_derived", "interest_overdue_derived",
+            "fee_charges_overdue_derived", "penalty_charges_overdue_derived", "total_overdue_derived", "overdue_since_date_derived");
+
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     private final JdbcTemplate jdbcTemplate;
@@ -271,6 +274,7 @@ public class LoanArrearsAgingServiceImpl implements LoanArrearsAgingService {
         BigDecimal totalOverDue = principalOverdue.add(interestOverdue).add(feeOverdue).add(penaltyOverdue);
         insertStatementBuilder.append(totalOverDue).append(",'");
         insertStatementBuilder.append(this.formatter.format(overDueSince)).append("')");
+        insertStatementBuilder.append(sqlGenerator.insertOnConflictUpdate(List.of("loan_id"), ARREARS_UPSERT_COLUMNS));
         return insertStatementBuilder.toString();
     }
 

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/jobs/updateloanarrearsageing/LoanArrearsAgeingUpdateHandlerTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/jobs/updateloanarrearsageing/LoanArrearsAgeingUpdateHandlerTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.jobs.updateloanarrearsageing;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.portfolio.loanaccount.service.LoanArrearsAgingService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class LoanArrearsAgeingUpdateHandlerTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private DatabaseSpecificSQLGenerator sqlGenerator;
+    @Mock
+    private LoanArrearsAgingService loanArrearsAgingService;
+
+    @Test
+    void updateLoanArrearsAgeingDetailsForAllLoansClearsTableTransactionallyAndUsesUpsert() {
+        when(sqlGenerator.currentBusinessDate()).thenReturn("DATE('2026-04-06')");
+        when(sqlGenerator.subDate(anyString(), anyString(), anyString())).thenReturn("DATE_SUB(...)");
+        when(sqlGenerator.insertOnConflictUpdate(anyList(), anyList())).thenReturn(" UPSERT_CLAUSE");
+        when(jdbcTemplate.queryForList(anyString(), eq(Long.class))).thenReturn(Collections.emptyList());
+        when(jdbcTemplate.batchUpdate(any(String[].class))).thenReturn(new int[0]);
+
+        LoanArrearsAgeingUpdateHandler handler = new LoanArrearsAgeingUpdateHandler(jdbcTemplate, sqlGenerator,
+                loanArrearsAgingService);
+
+        handler.updateLoanArrearsAgeingDetailsForAllLoans();
+
+        verify(jdbcTemplate).update("delete from m_loan_arrears_aging");
+        ArgumentCaptor<String[]> statementsCaptor = ArgumentCaptor.forClass(String[].class);
+        verify(jdbcTemplate).batchUpdate(statementsCaptor.capture());
+        assertTrue(statementsCaptor.getValue()[0].contains("UPSERT_CLAUSE"));
+    }
+}

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImplTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImplTest.java
@@ -24,10 +24,10 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
-import java.util.EnumMap;
-import java.util.HashMap;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;

--- a/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImplTest.java
+++ b/fineract-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/service/LoanArrearsAgingServiceImplTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePeriodData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class LoanArrearsAgingServiceImplTest {
+
+    private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+    private final BusinessEventNotifierService businessEventNotifierService = Mockito.mock(BusinessEventNotifierService.class);
+    private final DatabaseSpecificSQLGenerator sqlGenerator = Mockito.mock(DatabaseSpecificSQLGenerator.class);
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+        MoneyHelper.clearCache();
+    }
+
+    @Test
+    void createInsertStatementsUsesUpsertForOriginalScheduleRows() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "UTC", null));
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
+        ThreadLocalContextUtil
+                .setBusinessDates(new HashMap<>(new EnumMap<>(Map.of(BusinessDateType.BUSINESS_DATE, LocalDate.of(2026, 4, 6)))));
+        MoneyHelper.initializeTenantRoundingMode("default", 6);
+        when(sqlGenerator.insertOnConflictUpdate(anyList(), anyList())).thenReturn(" UPSERT_CLAUSE");
+        LoanArrearsAgingServiceImpl service = new LoanArrearsAgingServiceImpl(jdbcTemplate, businessEventNotifierService, sqlGenerator);
+
+        LoanSchedulePeriodData period = LoanSchedulePeriodData.repaymentOnlyPeriod(1, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31),
+                new BigDecimal("100"), null, new BigDecimal("25"), BigDecimal.ZERO, BigDecimal.ZERO);
+        LoanSchedulePeriodData updatedPeriod = LoanSchedulePeriodData.withPaidDetail(period, false, BigDecimal.ZERO, BigDecimal.ZERO,
+                BigDecimal.ZERO, BigDecimal.ZERO);
+        Map<Long, List<LoanSchedulePeriodData>> scheduleDate = new HashMap<>();
+        scheduleDate.put(99L, new ArrayList<>(List.of(updatedPeriod)));
+
+        List<String> insertStatements = new ArrayList<>();
+        service.createInsertStatements(insertStatements, scheduleDate, true);
+
+        assertEquals(1, insertStatements.size());
+        assertTrue(insertStatements.get(0).contains("UPSERT_CLAUSE"));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/savings/SavingsInterestPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/savings/SavingsInterestPostingTest.java
@@ -53,8 +53,10 @@ public class SavingsInterestPostingTest extends BaseSavingsIntegrationTest {
             Long productId = product.getResourceId();
 
             // Create accounts
+            // Keep approval and activation deterministic; the shared integration client and result list are not safe
+            // to drive through a parallel stream.
             IntStream.range(0, 200)//
-                    .parallel().mapToObj(i -> applySavingsRequest(clientId, productId, "01 January 2023"))//
+                    .mapToObj(i -> applySavingsRequest(clientId, productId, "01 January 2023"))//
                     .map(this::applySavingsAccount) //
                     .mapToLong(PostSavingsAccountsResponse::getResourceId) //
                     .forEach(savingsId -> {


### PR DESCRIPTION
## Summary
- replace the nightly arrears refresh `TRUNCATE` with transactional `DELETE`
- make arrears inserts idempotent with dialect-aware upsert SQL
- cover the new SQL generation and handler behavior with targeted tests

## Diagnosis
The staging failures are not caused by a permanently bad row for loan `14759`.

I checked the staging database directly and found that:
- the failing `INSERT ... SELECT` returns exactly one source row for loan `14759`
- the product recalculation details are not duplicated for that product
- manual reruns succeed, while the nightly job fails on different loans across different dates

That pattern points to a race during the full refresh: another code path can insert/update a single `m_loan_arrears_aging` row after the job clears the table but before the bulk insert reaches that loan, which then produces the duplicate primary key error.

## Fix
- use `DELETE FROM m_loan_arrears_aging` so the refresh stays inside the surrounding transaction
- append a database-specific upsert clause to both bulk and per-loan arrears insert statements
- preserve compatibility for both MariaDB/MySQL and PostgreSQL

## Verification
```bash
./gradlew :fineract-core:test --tests org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGeneratorTest
./gradlew :fineract-loan:test --tests org.apache.fineract.portfolio.loanaccount.jobs.updateloanarrearsageing.LoanArrearsAgeingUpdateHandlerTest --tests org.apache.fineract.portfolio.loanaccount.service.LoanArrearsAgingServiceImplTest
```
