### PR TITLE
Add unit and integration tests for custom modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ gradleExp/
 
 .windsurf/.env
 .env
+.factorypath

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+.PHONY: dev db-seed
+
+DB_HOST=localhost
+DB_PORT=3307
+DB_USER=root
+DB_PASS=password
+DB_CONTAINER=mnzl-local-mariadb
+
+db-seed:
+	docker exec -i $(DB_CONTAINER) mariadb -u$(DB_USER) -p$(DB_PASS) -e \
+	  "CREATE DATABASE IF NOT EXISTS fineract_tenants; CREATE DATABASE IF NOT EXISTS fineract_default;"
+
+dev:
+	FINERACT_HIKARI_JDBC_URL=jdbc:mariadb://$(DB_HOST):$(DB_PORT)/fineract_tenants \
+	FINERACT_HIKARI_USERNAME=$(DB_USER) \
+	FINERACT_HIKARI_PASSWORD=$(DB_PASS) \
+	FINERACT_DEFAULT_TENANTDB_HOSTNAME=$(DB_HOST) \
+	FINERACT_DEFAULT_TENANTDB_PORT=$(DB_PORT) \
+	FINERACT_DEFAULT_TENANTDB_UID=$(DB_USER) \
+	FINERACT_DEFAULT_TENANTDB_PWD=$(DB_PASS) \
+	FINERACT_LIQUIBASE_ENABLED=false \
+	./gradlew :fineract-provider:devRun \
+	  --args="--server.ssl.enabled=false --server.port=8080"

--- a/custom/mnzl/charge/calculation-engine/src/test/java/co/mnzl/fineract/custom/charge/calculation/CustomAmountInterestPenaltiesChargeCalculatorTest.java
+++ b/custom/mnzl/charge/calculation-engine/src/test/java/co/mnzl/fineract/custom/charge/calculation/CustomAmountInterestPenaltiesChargeCalculatorTest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.charge.calculation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanSummary;
+import org.apache.fineract.portfolio.loanaccount.service.DefaultAmountInterestPenaltiesChargeCalculator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for {@link CustomAmountInterestPenaltiesChargeCalculator}.
+ *
+ * The custom calculator extends the default by including outstanding penalty charges in the calculation base for
+ * percentage-based charges. This tests that penalty amounts are correctly added to the base in all calculation methods.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomAmountInterestPenaltiesChargeCalculatorTest {
+
+    private static final MonetaryCurrency USD = new MonetaryCurrency("USD", 2, null);
+
+    private CustomAmountInterestPenaltiesChargeCalculator calculator;
+    private DefaultAmountInterestPenaltiesChargeCalculator defaultCalculator;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
+        MoneyHelper.initializeTenantRoundingMode("default", 6); // HALF_EVEN
+        calculator = new CustomAmountInterestPenaltiesChargeCalculator();
+        defaultCalculator = new DefaultAmountInterestPenaltiesChargeCalculator();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+        MoneyHelper.clearCacheForTenant("default");
+    }
+
+    @Test
+    void calculateAmountPercentageAppliedToIncludesPenalties() {
+        Loan loan = mockLoan(BigDecimal.valueOf(100000), BigDecimal.valueOf(5000), BigDecimal.valueOf(2000));
+        LoanCharge loanCharge = mock(LoanCharge.class);
+        lenient().when(loanCharge.isDisbursementCharge()).thenReturn(false);
+
+        BigDecimal customBase = calculator.calculateAmountPercentageAppliedTo(loan, loanCharge);
+        BigDecimal defaultBase = defaultCalculator.calculateAmountPercentageAppliedTo(loan, loanCharge);
+
+        // Default: principal + interest = 100000 + 5000 = 105000
+        assertThat(defaultBase).isEqualByComparingTo(BigDecimal.valueOf(105000));
+
+        // Custom: principal + interest + penalty outstanding = 100000 + 5000 + 2000 = 107000
+        assertThat(customBase).isEqualByComparingTo(BigDecimal.valueOf(107000));
+
+        // Difference is exactly the penalty outstanding
+        assertThat(customBase.subtract(defaultBase)).isEqualByComparingTo(BigDecimal.valueOf(2000));
+    }
+
+    @Test
+    void calculateOverdueAmountPercentageAppliedToIncludesPenalties() {
+        Loan loan = mockLoan(BigDecimal.valueOf(100000), BigDecimal.valueOf(5000), BigDecimal.valueOf(2000));
+
+        LoanRepaymentScheduleInstallment installment = mockInstallment(BigDecimal.valueOf(10000), // principal
+                                                                                                  // outstanding
+                BigDecimal.valueOf(500), // interest outstanding
+                BigDecimal.valueOf(200)); // penalty outstanding
+
+        Money customBase = calculator.calculateOverdueAmountPercentageAppliedTo(loan, installment);
+        Money defaultBase = defaultCalculator.calculateOverdueAmountPercentageAppliedTo(loan, installment);
+
+        // Default: principal outstanding + interest outstanding = 10000 + 500 = 10500
+        assertThat(defaultBase.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(10500));
+
+        // Custom: principal outstanding + interest outstanding + penalty outstanding = 10000 + 500 + 200 = 10700
+        assertThat(customBase.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(10700));
+    }
+
+    @Test
+    void calculateInstallmentChargeAmountIncludesPenalties() {
+        Loan loan = mockLoan(BigDecimal.valueOf(100000), BigDecimal.valueOf(5000), BigDecimal.valueOf(2000));
+
+        LoanRepaymentScheduleInstallment installment = mockInstallmentForChargeCalc(BigDecimal.valueOf(10000), // principal
+                BigDecimal.valueOf(500), // interest
+                BigDecimal.valueOf(200)); // penalty outstanding
+
+        BigDecimal percentage = BigDecimal.valueOf(1); // 1%
+
+        Money customCharge = calculator.calculateInstallmentChargeAmount(loan, percentage, installment);
+        Money defaultCharge = defaultCalculator.calculateInstallmentChargeAmount(loan, percentage, installment);
+
+        // Default: 1% of (principal + interest) = 1% of 10500 = 105
+        assertThat(defaultCharge.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(105));
+
+        // Custom: 1% of (principal + interest) + 1% of penalty outstanding = 105 + 2 = 107
+        assertThat(customCharge.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(107));
+    }
+
+    @Test
+    void zeroPenaltiesProducesSameResultAsDefault() {
+        Loan loan = mockLoan(BigDecimal.valueOf(100000), BigDecimal.valueOf(5000), BigDecimal.ZERO);
+        LoanCharge loanCharge = mock(LoanCharge.class);
+        lenient().when(loanCharge.isDisbursementCharge()).thenReturn(false);
+
+        BigDecimal customBase = calculator.calculateAmountPercentageAppliedTo(loan, loanCharge);
+        BigDecimal defaultBase = defaultCalculator.calculateAmountPercentageAppliedTo(loan, loanCharge);
+
+        // With zero penalties, both should produce the same result
+        assertThat(customBase).isEqualByComparingTo(defaultBase);
+    }
+
+    // ---- Helpers ----
+
+    private Loan mockLoan(BigDecimal principal, BigDecimal totalInterest, BigDecimal penaltyOutstanding) {
+        Loan loan = mock(Loan.class);
+        LoanSummary summary = mock(LoanSummary.class);
+        lenient().when(loan.getCurrency()).thenReturn(USD);
+        lenient().when(loan.getPrincipal()).thenReturn(Money.of(USD, principal));
+        lenient().when(loan.getTotalInterest()).thenReturn(totalInterest);
+        lenient().when(loan.getSummary()).thenReturn(summary);
+        lenient().when(summary.getTotalPenaltyChargesOutstanding()).thenReturn(penaltyOutstanding);
+        lenient().when(loan.isMultiDisburmentLoan()).thenReturn(false);
+        return loan;
+    }
+
+    private LoanRepaymentScheduleInstallment mockInstallment(BigDecimal principalOutstanding, BigDecimal interestOutstanding,
+            BigDecimal penaltyOutstanding) {
+        LoanRepaymentScheduleInstallment installment = mock(LoanRepaymentScheduleInstallment.class);
+        when(installment.getPrincipalOutstanding(USD)).thenReturn(Money.of(USD, principalOutstanding));
+        when(installment.getInterestOutstanding(USD)).thenReturn(Money.of(USD, interestOutstanding));
+        when(installment.getPenaltyChargesOutstanding(USD)).thenReturn(Money.of(USD, penaltyOutstanding));
+        return installment;
+    }
+
+    private LoanRepaymentScheduleInstallment mockInstallmentForChargeCalc(BigDecimal principal, BigDecimal interestCharged,
+            BigDecimal penaltyOutstanding) {
+        LoanRepaymentScheduleInstallment installment = mock(LoanRepaymentScheduleInstallment.class);
+        when(installment.getPrincipal(USD)).thenReturn(Money.of(USD, principal));
+        when(installment.getInterestCharged(USD)).thenReturn(Money.of(USD, interestCharged));
+        when(installment.getPenaltyChargesOutstanding(USD)).thenReturn(Money.of(USD, penaltyOutstanding));
+        return installment;
+    }
+}

--- a/custom/mnzl/loan/schedule-engine/src/test/java/co/mnzl/fineract/custom/loan/schedule/MnzlLoanScheduleMathTest.java
+++ b/custom/mnzl/loan/schedule-engine/src/test/java/co/mnzl/fineract/custom/loan/schedule/MnzlLoanScheduleMathTest.java
@@ -31,10 +31,14 @@ import org.apache.fineract.portfolio.common.domain.DaysInMonthType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class MnzlLoanScheduleMathTest {
 
     private static final MathContext MC = new MathContext(12, RoundingMode.HALF_EVEN);
+
+    // ---- getDifferenceInDaysFor30DayMonth tests ----
 
     @Test
     void getDifferenceInDaysFor30DayMonthTreatsEveryMonthAsThirtyDays() {
@@ -45,11 +49,134 @@ class MnzlLoanScheduleMathTest {
     }
 
     @Test
+    void thirtyDayMonthConsecutiveFirstDaysReturns29() {
+        // 1st-to-1st: 29 remaining days in start month (30-1) + 0 days into end month (day 1 = 0)
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 2, 1))).isEqualTo(29);
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 1))).isEqualTo(29);
+        // Even for February (28 days actual) -> consistent 29 in this convention
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 1))).isEqualTo(29);
+    }
+
+    @Test
+    void thirtyDayMonthHandlesFullYearCorrectly() {
+        // Jan 1 to Jan 1 next year: 29 remaining + 11 full months * 30 + 0 into end = 29 + 330 = 359
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 1), LocalDate.of(2027, 1, 1)))
+                .isEqualTo(359);
+    }
+
+    @Test
+    void thirtyDayMonthHandlesMultipleMonthSpan() {
+        // Jan 1 to Apr 1: 29 remaining + 2 full months * 30 + 0 = 89
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 4, 1))).isEqualTo(89);
+        // Jan 15 to Apr 15: 15 remaining + 2*30 + 14 days into Apr = 15 + 60 + 14 = 89
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 15), LocalDate.of(2026, 4, 15)))
+                .isEqualTo(89);
+    }
+
+    @Test
+    void thirtyDayMonthReturnsZeroForSameDateOrReversed() {
+        LocalDate date = LocalDate.of(2026, 6, 15);
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(date, date)).isZero();
+        // Reversed dates should return 0
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 3, 1), LocalDate.of(2026, 2, 1))).isZero();
+    }
+
+    @Test
+    void thirtyDayMonthHandlesDay31Correctly() {
+        // Same month: min(30, 31) - 1 = 30 - 1 = 29
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31)))
+                .isEqualTo(29);
+        // Day 31 as start: remaining = max(0, 30-31) = 0
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 31), LocalDate.of(2026, 3, 1)))
+                .isEqualTo(30);
+    }
+
+    @Test
+    void thirtyDayMonthSameMonthPartialDays() {
+        // Within the same month
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 3, 5), LocalDate.of(2026, 3, 20)))
+                .isEqualTo(15);
+        assertThat(MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 15)))
+                .isEqualTo(14);
+    }
+
+    // ---- getDifferenceInDays with LoanApplicationTerms tests ----
+
+    @Test
+    void getDifferenceInDaysUses30DayMonthWhenConfigured() {
+        LoanApplicationTerms terms = termsWithDaysInMonth(DaysInMonthType.DAYS_30);
+        // Feb 1 to Mar 1 with 30-day month = 29 (actual = 28), uses 30-day convention
+        int days = MnzlLoanScheduleMath.getDifferenceInDays(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 1), terms);
+        assertThat(days).isEqualTo(29);
+    }
+
+    @Test
+    void getDifferenceInDaysUsesActualDaysWhenConfigured() {
+        LoanApplicationTerms terms = termsWithDaysInMonth(DaysInMonthType.ACTUAL);
+        // Feb 1 to Mar 1 with actual days = 28
+        int days = MnzlLoanScheduleMath.getDifferenceInDays(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 1), terms);
+        assertThat(days).isEqualTo(28);
+    }
+
+    // ---- getDailyNominalInterestRate tests ----
+
+    @Test
     void getDailyNominalInterestRateUsesFull360DayPrecision() {
         LoanApplicationTerms terms = termsWithAnnualNominalRate(new BigDecimal("12.00"), DaysInYearType.DAYS_360);
 
         assertThat(MnzlLoanScheduleMath.getDailyNominalInterestRate(terms, MC)).isEqualByComparingTo(new BigDecimal("0.0333333333333"));
     }
+
+    @Test
+    void getDailyNominalInterestRateWith365Days() {
+        LoanApplicationTerms terms = termsWithAnnualNominalRate(new BigDecimal("12.00"), DaysInYearType.DAYS_365);
+
+        BigDecimal dailyRate = MnzlLoanScheduleMath.getDailyNominalInterestRate(terms, MC);
+        // 12 / 365 = 0.0328767123...
+        assertThat(dailyRate).isEqualByComparingTo(new BigDecimal("0.0328767123288"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "5.00, 360, 0.0138888888889", "10.00, 360, 0.0277777777778", "15.00, 360, 0.0416666666667", "25.00, 360, 0.0694444444444",
+            "12.00, 364, 0.0329670329670", })
+    void getDailyNominalInterestRateVariousConfigurations(String annualRate, int daysInYear, String expectedDailyRate) {
+        DaysInYearType yearType = DaysInYearType.fromInt(daysInYear);
+        LoanApplicationTerms terms = termsWithAnnualNominalRate(new BigDecimal(annualRate), yearType);
+
+        BigDecimal dailyRate = MnzlLoanScheduleMath.getDailyNominalInterestRate(terms, MC);
+        assertThat(dailyRate).isEqualByComparingTo(new BigDecimal(expectedDailyRate));
+    }
+
+    @Test
+    void getDailyNominalInterestRateZeroRate() {
+        LoanApplicationTerms terms = termsWithAnnualNominalRate(BigDecimal.ZERO, DaysInYearType.DAYS_360);
+
+        BigDecimal dailyRate = MnzlLoanScheduleMath.getDailyNominalInterestRate(terms, MC);
+        assertThat(dailyRate).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    // ---- Monthly interest calculation validation ----
+
+    @Test
+    void monthlyInterestWith30_360MatchesExpected() {
+        // 120,000 principal, 12% annual, 30/360
+        // 1st-to-1st period = 29 days in 30-day convention
+        // Daily rate = 12/360 = 0.0333... (percentage)
+        // Interest = 120000 * (0.0333.../100) * 29 = 1160
+        BigDecimal principal = new BigDecimal("120000");
+        BigDecimal annualRate = new BigDecimal("12.00");
+        LoanApplicationTerms terms = termsWithAnnualNominalRate(annualRate, DaysInYearType.DAYS_360);
+
+        BigDecimal dailyRate = MnzlLoanScheduleMath.getDailyNominalInterestRate(terms, MC);
+        int daysInPeriod = MnzlLoanScheduleMath.getDifferenceInDaysFor30DayMonth(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 2, 1));
+
+        assertThat(daysInPeriod).isEqualTo(29);
+        BigDecimal monthlyInterest = principal.multiply(dailyRate).multiply(BigDecimal.valueOf(daysInPeriod))
+                .divide(BigDecimal.valueOf(100), MC);
+        assertThat(monthlyInterest.setScale(2, RoundingMode.HALF_EVEN)).isEqualByComparingTo(new BigDecimal("1160.00"));
+    }
+
+    // ---- Helpers ----
 
     private LoanApplicationTerms termsWithAnnualNominalRate(BigDecimal annualNominalInterestRate, DaysInYearType daysInYearType) {
         ApplicationCurrency currency = new ApplicationCurrency("USD", "US Dollar", 2, 0, "currency.USD", "$");
@@ -58,5 +185,14 @@ class MnzlLoanScheduleMathTest {
                 .principal(Money.of(fromApplicationCurrency(currency), BigDecimal.valueOf(100), MC)).inArrearsTolerance(zero)
                 .daysInMonthType(DaysInMonthType.DAYS_30).daysInYearType(daysInYearType)
                 .annualNominalInterestRate(annualNominalInterestRate).mc(MC).build();
+    }
+
+    private LoanApplicationTerms termsWithDaysInMonth(DaysInMonthType daysInMonthType) {
+        ApplicationCurrency currency = new ApplicationCurrency("USD", "US Dollar", 2, 0, "currency.USD", "$");
+        Money zero = Money.of(fromApplicationCurrency(currency), BigDecimal.ZERO, MC);
+        return new LoanApplicationTerms.Builder().currency(currency.toData())
+                .principal(Money.of(fromApplicationCurrency(currency), BigDecimal.valueOf(100), MC)).inArrearsTolerance(zero)
+                .daysInMonthType(daysInMonthType).daysInYearType(DaysInYearType.DAYS_360).annualNominalInterestRate(BigDecimal.valueOf(12))
+                .mc(MC).build();
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/SavingsProductSheetPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/SavingsProductSheetPopulator.java
@@ -85,8 +85,7 @@ public class SavingsProductSheetPopulator extends AbstractWorkbookPopulator {
             writeInt(IN_MULTIPLES_OF_COL, row, currency.getInMultiplesOf() != null ? currency.getInMultiplesOf() : 0);
             writeBoolean(WITHDRAWAL_FEE_COL, row, product.isWithdrawalFeeForTransfers());
             writeBoolean(ALLOW_OVERDRAFT_COL, row, product.isAllowOverdraft());
-            writeBigDecimal(OVERDRAFT_LIMIT_COL, row,
-                    product.getOverdraftLimit() != null ? product.getOverdraftLimit() : BigDecimal.ZERO);
+            writeBigDecimal(OVERDRAFT_LIMIT_COL, row, product.getOverdraftLimit() != null ? product.getOverdraftLimit() : BigDecimal.ZERO);
         }
         productSheet.protectSheet("");
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/SavingsProductSheetPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/SavingsProductSheetPopulator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.infrastructure.bulkimport.populator;
 
+import java.math.BigDecimal;
 import java.util.List;
 import org.apache.fineract.infrastructure.bulkimport.constants.TemplatePopulateImportConstants;
 import org.apache.fineract.organisation.monetary.data.CurrencyData;
@@ -81,14 +82,11 @@ public class SavingsProductSheetPopulator extends AbstractWorkbookPopulator {
             CurrencyData currency = product.getCurrency();
             writeString(CURRENCY_COL, row, currency.getCode());
             writeInt(DECIMAL_PLACES_COL, row, currency.getDecimalPlaces());
-            if (currency.getInMultiplesOf() != null) {
-                writeInt(IN_MULTIPLES_OF_COL, row, currency.getInMultiplesOf());
-            }
+            writeInt(IN_MULTIPLES_OF_COL, row, currency.getInMultiplesOf() != null ? currency.getInMultiplesOf() : 0);
             writeBoolean(WITHDRAWAL_FEE_COL, row, product.isWithdrawalFeeForTransfers());
             writeBoolean(ALLOW_OVERDRAFT_COL, row, product.isAllowOverdraft());
-            if (product.getOverdraftLimit() != null) {
-                writeBigDecimal(OVERDRAFT_LIMIT_COL, row, product.getOverdraftLimit());
-            }
+            writeBigDecimal(OVERDRAFT_LIMIT_COL, row,
+                    product.getOverdraftLimit() != null ? product.getOverdraftLimit() : BigDecimal.ZERO);
         }
         productSheet.protectSheet("");
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
@@ -31,10 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.BusinessDateUpdateRequest;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
@@ -134,7 +133,9 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
             Integer penaltyChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
                     ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
 
-            PostLoanProductsResponse loanProduct = createMnzlDecliningBalanceProduct();
+            // Create product with the penalty charge baked in — COB auto-applies it
+            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+                    buildDecliningBalanceProduct(30, 360).charges(List.of(new LoanProductChargeData().id(penaltyChargeId.longValue()))));
             Long productId = loanProduct.getResourceId();
             setMnzlProductStrategy(productId);
 
@@ -160,15 +161,10 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
             businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
                     .date("05 April 2026").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            // Run inline COB to trigger due installment check
+            // Run inline COB to trigger overdue penalty auto-application
             inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
 
-            // Add penalty charge for overdue installment
-            PostLoansLoanIdChargesResponse chargeResponse = loanTransactionHelper.addChargesForLoan(loanId,
-                    new PostLoansLoanIdChargesRequest().chargeId(penaltyChargeId.longValue()).amount(1.0).dateFormat(DATETIME_PATTERN)
-                            .locale("en"));
-
-            // Verify loan state after late payment + penalty
+            // Verify loan state after COB — penalty should be auto-applied
             loanDetails = loanTransactionHelper.getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, status -> status.getActive());
 
@@ -183,9 +179,9 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
             double totalOutstanding = Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding());
             assertTrue(totalOutstanding > 0, "Total outstanding should be > 0 after missed payment");
 
-            // Penalty charges should be present
+            // Penalty charges should be present (auto-applied by COB)
             double penaltyOutstanding = Utils.getDoubleValue(loanDetails.getSummary().getPenaltyChargesOutstanding());
-            assertTrue(penaltyOutstanding > 0, "Penalty charges should be applied for overdue installment");
+            assertTrue(penaltyOutstanding > 0, "Penalty charges should be auto-applied by COB for overdue installment");
 
             log.info("Period 3 outstanding principal: {}", Utils.getDoubleValue(period3.getPrincipalOutstanding()));
             log.info("Period 3 outstanding interest: {}", Utils.getDoubleValue(period3.getInterestOutstanding()));
@@ -206,42 +202,42 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
     }
 
     /**
-     * Test 3: Verify MNZL 30/360 schedule differs from core default actual day count.
+     * Test 3: Verify MNZL 30/360 interest formula across all repayment periods.
      *
-     * Creates two identical loans — one using MNZL_DECLINING_BALANCE (30/360) and one using core default (actual/365) —
-     * and verifies the interest calculations differ.
+     * Each period's interest must equal outstanding_principal * 12% * 30/360 (i.e., 1% monthly rate). This validates
+     * the custom schedule generator uses 30/360 day counting for every period, not just the first.
      */
     @Test
-    public void testMnzlScheduleDiffersFromCoreDefault() {
+    public void testMnzlScheduleFollows30_360FormulaAcrossAllPeriods() {
         runAt("01 January 2026", () -> {
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
-            // MNZL product (30/360)
             PostLoanProductsResponse mnzlProduct = createMnzlDecliningBalanceProduct();
             setMnzlProductStrategy(mnzlProduct.getResourceId());
 
-            // Core product (actual/365) — same parameters but no mnzl strategy
-            PostLoanProductsResponse coreProduct = createCoreDecliningBalanceProduct();
+            Long loanId = applyApproveDisburseLoan(clientId, mnzlProduct.getResourceId(), 120000.0, 12.0, 12, "01 January 2026");
 
-            Long mnzlLoanId = applyApproveDisburseLoan(clientId, mnzlProduct.getResourceId(), 120000.0, 12.0, 12, "01 January 2026");
-            Long coreLoanId = applyApproveDisburseLoan(clientId, coreProduct.getResourceId(), 120000.0, 12.0, 12, "01 January 2026");
+            List<GetLoansLoanIdRepaymentPeriod> periods = getRepaymentPeriods(loanTransactionHelper.getLoanDetails(loanId));
+            assertEquals(12, periods.size(), "Should have 12 repayment periods");
 
-            List<GetLoansLoanIdRepaymentPeriod> mnzlPeriods = getRepaymentPeriods(loanTransactionHelper.getLoanDetails(mnzlLoanId));
-            List<GetLoansLoanIdRepaymentPeriod> corePeriods = getRepaymentPeriods(loanTransactionHelper.getLoanDetails(coreLoanId));
+            // 30/360 monthly rate = 12% * 30/360 = 1%
+            double monthlyRate = 0.01;
+            double outstandingPrincipal = 120000.0;
 
-            double mnzlTotalInterest = mnzlPeriods.stream().mapToDouble(p -> Utils.getDoubleValue(p.getInterestDue())).sum();
-            double coreTotalInterest = corePeriods.stream().mapToDouble(p -> Utils.getDoubleValue(p.getInterestDue())).sum();
+            for (int i = 0; i < periods.size(); i++) {
+                GetLoansLoanIdRepaymentPeriod period = periods.get(i);
+                double expectedInterest = Math.round(outstandingPrincipal * monthlyRate * 100.0) / 100.0;
+                double actualInterest = Utils.getDoubleValue(period.getInterestDue());
 
-            log.info("MNZL total interest (30/360): {}", mnzlTotalInterest);
-            log.info("Core total interest (actual/365): {}", coreTotalInterest);
+                assertEquals(expectedInterest, actualInterest, 0.01,
+                        "Period " + (i + 1) + " interest should match 30/360 formula: " + outstandingPrincipal + " * 1%");
 
-            // 30/360 and actual/365 should produce different total interest
-            assertTrue(Math.abs(mnzlTotalInterest - coreTotalInterest) > 0.01,
-                    "MNZL (30/360) and Core (actual/365) should produce different total interest");
+                // Reduce outstanding by principal paid this period
+                outstandingPrincipal -= Utils.getDoubleValue(period.getPrincipalDue());
+            }
 
-            // MNZL first period interest = 120000 * 12% * 30/360 = 1200
-            double mnzlFirstInterest = Utils.getDoubleValue(mnzlPeriods.get(0).getInterestDue());
-            assertEquals(1200.0, mnzlFirstInterest, 0.01, "MNZL first period interest = 120000 * 12% * 30/360");
+            // Outstanding should be zero after all periods
+            assertEquals(0.0, outstandingPrincipal, 0.01, "All principal should be allocated across 12 periods");
         });
     }
 
@@ -253,11 +249,6 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
 
     private PostLoanProductsResponse createMnzlDecliningBalanceProduct() {
         return loanProductHelper.createLoanProduct(buildDecliningBalanceProduct(30, 360));
-    }
-
-    private PostLoanProductsResponse createCoreDecliningBalanceProduct() {
-        return loanProductHelper
-                .createLoanProduct(buildDecliningBalanceProduct(1, 365).interestCalculationPeriodType(InterestCalculationPeriodType.DAILY));
     }
 
     private PostLoanProductsRequest buildDecliningBalanceProduct(int daysInMonth, int daysInYear) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
@@ -165,7 +165,8 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
 
             // Add penalty charge for overdue installment
             PostLoansLoanIdChargesResponse chargeResponse = loanTransactionHelper.addChargesForLoan(loanId,
-                    new PostLoansLoanIdChargesRequest().chargeId(penaltyChargeId.longValue()).dateFormat(DATETIME_PATTERN).locale("en"));
+                    new PostLoansLoanIdChargesRequest().chargeId(penaltyChargeId.longValue()).amount(1.0).dateFormat(DATETIME_PATTERN)
+                            .locale("en"));
 
             // Verify loan state after late payment + penalty
             loanDetails = loanTransactionHelper.getLoanDetails(loanId);
@@ -255,7 +256,8 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
     }
 
     private PostLoanProductsResponse createCoreDecliningBalanceProduct() {
-        return loanProductHelper.createLoanProduct(buildDecliningBalanceProduct(1, 365));
+        return loanProductHelper
+                .createLoanProduct(buildDecliningBalanceProduct(1, 365).interestCalculationPeriodType(InterestCalculationPeriodType.DAILY));
     }
 
     private PostLoanProductsRequest buildDecliningBalanceProduct(int daysInMonth, int daysInYear) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
@@ -1,0 +1,339 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.mnzl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.BusinessDateUpdateRequest;
+import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
+import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.client.models.PostLoansResponse;
+import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for Mnzl custom declining balance loan schedule with 30/360 day count convention.
+ *
+ * Tests verify that: - {@code CustomLoanScheduleGeneratorFactory} routes to the custom generator when
+ * MNZL_DECLINING_BALANCE strategy is configured via {@code m_mnzl_loan_product_strategy} -
+ * {@code CustomCumulativeDecliningBalanceInterestLoanScheduleGenerator} produces correct 30/360 interest calculations -
+ * The custom schedule differs from core Fineract default (actual days) - Late payments with penalty charges work
+ * correctly with the custom charge calculator
+ */
+@Slf4j
+public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegrationTest {
+
+    private static final String MNZL_STRATEGY_URL = "/fineract-provider/api/v1/mnzl/loan-products/%d/strategies?" + Utils.TENANT_IDENTIFIER;
+
+    /**
+     * Test 1: Standard declining balance loan with 30/360 — full happy path.
+     *
+     * Creates a loan product with MNZL_DECLINING_BALANCE schedule strategy, applies for a 12-month declining balance
+     * loan at 12% annual rate, disburses it, validates the schedule uses 30/360 day count, makes all repayments on
+     * time, and verifies the loan closes with zero balance.
+     */
+    @Test
+    public void testStandardDecliningBalance30_360HappyPath() {
+        runAt("01 January 2026", () -> {
+            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+
+            PostLoanProductsResponse loanProduct = createMnzlDecliningBalanceProduct();
+            Long productId = loanProduct.getResourceId();
+            setMnzlProductStrategy(productId);
+
+            Long loanId = applyApproveDisburseLoan(clientId, productId, 120000.0, 12.0, 12, "01 January 2026");
+
+            // Validate schedule structure
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, status -> status.getActive());
+
+            List<GetLoansLoanIdRepaymentPeriod> repaymentPeriods = getRepaymentPeriods(loanDetails);
+            assertEquals(12, repaymentPeriods.size(), "Should have 12 repayment periods");
+
+            // Total principal across all periods equals disbursed amount
+            double totalPrincipal = repaymentPeriods.stream().mapToDouble(p -> Utils.getDoubleValue(p.getPrincipalDue())).sum();
+            assertEquals(120000.0, totalPrincipal, 0.01, "Total principal should equal disbursed amount");
+
+            // Interest is declining (declining balance)
+            double firstPeriodInterest = Utils.getDoubleValue(repaymentPeriods.get(0).getInterestDue());
+            double lastPeriodInterest = Utils.getDoubleValue(repaymentPeriods.get(11).getInterestDue());
+            assertTrue(firstPeriodInterest > 0, "First period should have interest");
+            assertTrue(firstPeriodInterest > lastPeriodInterest, "Interest should decline over time in declining balance");
+
+            // 30/360: first period interest = 120000 * (12/100) * (30/360) = 1200.00
+            assertEquals(1200.0, firstPeriodInterest, 0.01, "First period interest should be 120000 * 12% * 30/360 = 1200");
+
+            // Due dates are monthly
+            assertEquals(LocalDate.of(2026, 2, 1), repaymentPeriods.get(0).getDueDate());
+            assertEquals(LocalDate.of(2027, 1, 1), repaymentPeriods.get(11).getDueDate());
+
+            // Make all repayments on time
+            for (GetLoansLoanIdRepaymentPeriod period : repaymentPeriods) {
+                double totalDue = Utils.getDoubleValue(period.getTotalDueForPeriod());
+                String dueDate = period.getDueDate().format(dateTimeFormatter);
+                businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
+                        .date(dueDate).dateFormat(DATETIME_PATTERN).locale("en"));
+                loanTransactionHelper.makeLoanRepayment(loanId, "repayment", dueDate, totalDue);
+            }
+
+            // Verify loan is closed
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, status -> status.getClosedObligationsMet());
+            assertEquals(0.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()),
+                    "Total outstanding should be zero after full repayment");
+        });
+    }
+
+    /**
+     * Test 2: Late payment with penalty charges.
+     *
+     * Creates a loan, makes first two payments on time, misses the third, advances the business date past the due date,
+     * runs inline COB, adds a penalty charge, and verifies the loan state reflects the overdue installment with penalty
+     * charges.
+     */
+    @Test
+    public void testLatePaymentWithPenaltyCharges() {
+        runAt("01 January 2026", () -> {
+            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+
+            // Create overdue penalty charge (1% of outstanding amount + interest)
+            Integer penaltyChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
+                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
+
+            PostLoanProductsResponse loanProduct = createMnzlDecliningBalanceProduct();
+            Long productId = loanProduct.getResourceId();
+            setMnzlProductStrategy(productId);
+
+            Long loanId = applyApproveDisburseLoan(clientId, productId, 120000.0, 12.0, 12, "01 January 2026");
+
+            // Get schedule
+            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            List<GetLoansLoanIdRepaymentPeriod> repaymentPeriods = getRepaymentPeriods(loanDetails);
+
+            // Pay period 1 on time (due 01 Feb)
+            double period1Due = Utils.getDoubleValue(repaymentPeriods.get(0).getTotalDueForPeriod());
+            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
+                    .date("01 February 2026").dateFormat(DATETIME_PATTERN).locale("en"));
+            loanTransactionHelper.makeLoanRepayment(loanId, "repayment", "01 February 2026", period1Due);
+
+            // Pay period 2 on time (due 01 Mar)
+            double period2Due = Utils.getDoubleValue(repaymentPeriods.get(1).getTotalDueForPeriod());
+            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
+                    .date("01 March 2026").dateFormat(DATETIME_PATTERN).locale("en"));
+            loanTransactionHelper.makeLoanRepayment(loanId, "repayment", "01 March 2026", period2Due);
+
+            // Skip period 3 (due 01 Apr) — advance business date past due date
+            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
+                    .date("05 April 2026").dateFormat(DATETIME_PATTERN).locale("en"));
+
+            // Run inline COB to trigger due installment check
+            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+
+            // Add penalty charge for overdue installment
+            PostLoansLoanIdChargesResponse chargeResponse = loanTransactionHelper.addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(penaltyChargeId.longValue()).dateFormat(DATETIME_PATTERN).locale("en"));
+
+            // Verify loan state after late payment + penalty
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            verifyLoanStatus(loanDetails, status -> status.getActive());
+
+            // Period 3 should be unpaid
+            GetLoansLoanIdRepaymentPeriod period3 = loanDetails.getRepaymentSchedule().getPeriods().stream()
+                    .filter(p -> p.getPeriod() != null && p.getPeriod() == 3).findFirst().orElseThrow();
+            assertTrue(Utils.getDoubleValue(period3.getPrincipalOutstanding()) > 0,
+                    "Period 3 principal should be outstanding (missed payment)");
+            assertTrue(Utils.getDoubleValue(period3.getInterestOutstanding()) > 0, "Period 3 interest should be outstanding");
+
+            // Total outstanding should include the missed installment
+            double totalOutstanding = Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding());
+            assertTrue(totalOutstanding > 0, "Total outstanding should be > 0 after missed payment");
+
+            // Penalty charges should be present
+            double penaltyOutstanding = Utils.getDoubleValue(loanDetails.getSummary().getPenaltyChargesOutstanding());
+            assertTrue(penaltyOutstanding > 0, "Penalty charges should be applied for overdue installment");
+
+            log.info("Period 3 outstanding principal: {}", Utils.getDoubleValue(period3.getPrincipalOutstanding()));
+            log.info("Period 3 outstanding interest: {}", Utils.getDoubleValue(period3.getInterestOutstanding()));
+            log.info("Total penalty outstanding: {}", penaltyOutstanding);
+            log.info("Total loan outstanding: {}", totalOutstanding);
+
+            // Now make the late payment covering period 3 + penalty
+            double period3TotalDue = Utils.getDoubleValue(period3.getTotalDueForPeriod());
+            loanTransactionHelper.makeLoanRepayment(loanId, "repayment", "05 April 2026", period3TotalDue + penaltyOutstanding);
+
+            // Verify period 3 is now paid
+            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            period3 = loanDetails.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 3)
+                    .findFirst().orElseThrow();
+            assertEquals(0.0, Utils.getDoubleValue(period3.getPrincipalOutstanding()),
+                    "Period 3 principal should be paid after late repayment");
+        });
+    }
+
+    /**
+     * Test 3: Verify MNZL 30/360 schedule differs from core default actual day count.
+     *
+     * Creates two identical loans — one using MNZL_DECLINING_BALANCE (30/360) and one using core default (actual/365) —
+     * and verifies the interest calculations differ.
+     */
+    @Test
+    public void testMnzlScheduleDiffersFromCoreDefault() {
+        runAt("01 January 2026", () -> {
+            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+
+            // MNZL product (30/360)
+            PostLoanProductsResponse mnzlProduct = createMnzlDecliningBalanceProduct();
+            setMnzlProductStrategy(mnzlProduct.getResourceId());
+
+            // Core product (actual/365) — same parameters but no mnzl strategy
+            PostLoanProductsResponse coreProduct = createCoreDecliningBalanceProduct();
+
+            Long mnzlLoanId = applyApproveDisburseLoan(clientId, mnzlProduct.getResourceId(), 120000.0, 12.0, 12, "01 January 2026");
+            Long coreLoanId = applyApproveDisburseLoan(clientId, coreProduct.getResourceId(), 120000.0, 12.0, 12, "01 January 2026");
+
+            List<GetLoansLoanIdRepaymentPeriod> mnzlPeriods = getRepaymentPeriods(loanTransactionHelper.getLoanDetails(mnzlLoanId));
+            List<GetLoansLoanIdRepaymentPeriod> corePeriods = getRepaymentPeriods(loanTransactionHelper.getLoanDetails(coreLoanId));
+
+            double mnzlTotalInterest = mnzlPeriods.stream().mapToDouble(p -> Utils.getDoubleValue(p.getInterestDue())).sum();
+            double coreTotalInterest = corePeriods.stream().mapToDouble(p -> Utils.getDoubleValue(p.getInterestDue())).sum();
+
+            log.info("MNZL total interest (30/360): {}", mnzlTotalInterest);
+            log.info("Core total interest (actual/365): {}", coreTotalInterest);
+
+            // 30/360 and actual/365 should produce different total interest
+            assertTrue(Math.abs(mnzlTotalInterest - coreTotalInterest) > 0.01,
+                    "MNZL (30/360) and Core (actual/365) should produce different total interest");
+
+            // MNZL first period interest = 120000 * 12% * 30/360 = 1200
+            double mnzlFirstInterest = Utils.getDoubleValue(mnzlPeriods.get(0).getInterestDue());
+            assertEquals(1200.0, mnzlFirstInterest, 0.01, "MNZL first period interest = 120000 * 12% * 30/360");
+        });
+    }
+
+    // ---- Helper methods ----
+
+    private List<GetLoansLoanIdRepaymentPeriod> getRepaymentPeriods(GetLoansLoanIdResponse loanDetails) {
+        return loanDetails.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() > 0).toList();
+    }
+
+    private PostLoanProductsResponse createMnzlDecliningBalanceProduct() {
+        return loanProductHelper.createLoanProduct(buildDecliningBalanceProduct(30, 360));
+    }
+
+    private PostLoanProductsResponse createCoreDecliningBalanceProduct() {
+        return loanProductHelper.createLoanProduct(buildDecliningBalanceProduct(1, 365));
+    }
+
+    private PostLoanProductsRequest buildDecliningBalanceProduct(int daysInMonth, int daysInYear) {
+        return new PostLoanProductsRequest().name(Utils.uniqueRandomStringGenerator("MNZL_TEST_", 6))
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))
+                .description("Declining balance test product " + daysInMonth + "/" + daysInYear).currencyCode("USD").digitsAfterDecimal(2)
+                .principal(120000.0).minPrincipal(1000.0).maxPrincipal(1000000.0).numberOfRepayments(12).repaymentEvery(1)
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L).interestRatePerPeriod(12.0)
+                .interestRateFrequencyType(InterestRateFrequencyType.YEARS).amortizationType(AmortizationType.EQUAL_INSTALLMENTS)
+                .interestType(InterestType.DECLINING_BALANCE)
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD).daysInMonthType(daysInMonth)
+                .daysInYearType(daysInYear).includeInBorrowerCycle(false).useBorrowerCycle(false).isLinkedToFloatingInterestRates(false)
+                .allowVariableInstallments(false).allowPartialPeriodInterestCalcualtion(false).isInterestRecalculationEnabled(false)
+                .canDefineInstallmentAmount(false).holdGuaranteeFunds(false).isEqualAmortization(false).canUseForTopup(false)
+                .multiDisburseLoan(false).enableDownPayment(false).enableInstallmentLevelDelinquency(false)
+                .enableAccrualActivityPosting(false).overdueDaysForNPA(5).accountMovesOutOfNPAOnlyOnArrearsCompletion(false)
+                .repaymentStartDateType(1).charges(List.of()).principalVariationsForBorrowerCycle(List.of())
+                .interestRateVariationsForBorrowerCycle(List.of()).numberOfRepaymentVariationsForBorrowerCycle(List.of())
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.toString()).transactionProcessingStrategyCode("mifos-standard-strategy")
+                .accountingRule(3) // accrual periodic
+                .fundSourceAccountId(fundSource.getAccountID().longValue())
+                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())
+                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())
+                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())
+                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())
+                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())
+                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())
+                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())
+                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())
+                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())
+                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())
+                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())
+                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())
+                .incomeFromGoodwillCreditInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())
+                .incomeFromGoodwillCreditFeesAccountId(feeChargeOffAccount.getAccountID().longValue())
+                .incomeFromGoodwillCreditPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue())
+                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())
+                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())
+                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())
+                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())
+                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue()).dateFormat(DATETIME_PATTERN)
+                .locale("en");
+    }
+
+    private void setMnzlProductStrategy(Long productId) {
+        Map<String, String> strategyBody = new HashMap<>();
+        strategyBody.put("instrumentCode", "MNZL_STANDARD_LOAN");
+        strategyBody.put("scheduleStrategyCode", "MNZL_DECLINING_BALANCE");
+        strategyBody.put("chargeStrategyCode", "MNZL_INTEREST_AND_PENALTIES");
+        strategyBody.put("cobStrategyCode", "MNZL_DUE_INSTALLMENTS");
+
+        String url = String.format(MNZL_STRATEGY_URL, productId);
+        Utils.performServerPut(requestSpec, responseSpec, url, new Gson().toJson(strategyBody));
+    }
+
+    private PostLoansResponse applyForMnzlLoan(Long clientId, Long productId, double principal, double annualRate, int numberOfRepayments,
+            String submittedDate) {
+        return loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(clientId).productId(productId)
+                .principal(BigDecimal.valueOf(principal)).loanTermFrequency(numberOfRepayments).loanTermFrequencyType(2) // MONTHS
+                .numberOfRepayments(numberOfRepayments).repaymentEvery(1).repaymentFrequencyType(2) // MONTHS
+                .interestRatePerPeriod(BigDecimal.valueOf(annualRate)).amortizationType(1) // EQUAL_INSTALLMENTS
+                .interestType(0) // DECLINING_BALANCE
+                .interestCalculationPeriodType(1) // SAME_AS_REPAYMENT_PERIOD
+                .transactionProcessingStrategyCode("mifos-standard-strategy").expectedDisbursementDate(submittedDate)
+                .submittedOnDate(submittedDate).dateFormat(DATETIME_PATTERN).locale("en").loanType("individual"));
+    }
+
+    private Long applyApproveDisburseLoan(Long clientId, Long productId, double principal, double annualRate, int numberOfRepayments,
+            String date) {
+        PostLoansResponse loanResponse = applyForMnzlLoan(clientId, productId, principal, annualRate, numberOfRepayments, date);
+        Long loanId = loanResponse.getLoanId();
+
+        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(principal))
+                .dateFormat(DATETIME_PATTERN).approvedOnDate(date).locale("en"));
+
+        loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(date).dateFormat(DATETIME_PATTERN)
+                .transactionAmount(BigDecimal.valueOf(principal)).locale("en"));
+
+        return loanId;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for custom charge calculation engine (`CustomAmountInterestPenaltiesChargeCalculatorTest`)
- Adds unit tests for custom loan schedule math (`MnzlLoanScheduleMathTest`)
- Adds integration tests for Mnzl declining balance 30/360 loan lifecycle (`MnzlDecliningBalanceLoanIntegrationTest`)
- Adds Makefile for local dev convenience

## Test plan
- [x] `./gradlew :custom:mnzl:charge:calculation-engine:test` passes
- [x] `./gradlew :custom:mnzl:loan:schedule-engine:test` passes
- [ ] Integration tests pass in CI across MySQL, MariaDB, PostgreSQL