### PR TITLE
Apply loan grace period in working days instead of calendar days

### DIFF
--- a/custom/mnzl/loan/grace/build.gradle
+++ b/custom/mnzl/loan/grace/build.gradle
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+description = 'Custom Loan Working-Day Grace'
+
+group = 'co.mnzl.fineract.custom'
+
+base {
+    archivesName = 'custom-mnzl-loan-grace'
+}
+
+apply from: 'dependencies.gradle'

--- a/custom/mnzl/loan/grace/dependencies.gradle
+++ b/custom/mnzl/loan/grace/dependencies.gradle
@@ -20,20 +20,12 @@
 dependencies {
     implementation(project(':fineract-core'))
     implementation(project(':fineract-cob'))
+    implementation(project(':fineract-charge'))
     implementation(project(':fineract-loan'))
     implementation(project(':fineract-provider'))
-    implementation(project(':custom:mnzl:instrument:balloon-loan'))
-    implementation(project(':custom:mnzl:instrument:loan-api'))
-    implementation(project(':custom:mnzl:loan:cob'))
-    implementation(project(':custom:mnzl:loan:grace'))
-    implementation(project(':custom:mnzl:loan:job'))
-    implementation(project(':custom:mnzl:loan:schedule-api'))
-    implementation(project(':custom:mnzl:loan:schedule-engine'))
     implementation('org.springframework.boot:spring-boot-starter')
-    testImplementation(project(':fineract-provider'))
-    testImplementation('org.springframework.boot:spring-boot-starter-jdbc')
-    testImplementation('org.springframework.boot:spring-boot-starter-data-jpa')
-    testImplementation('org.eclipse.persistence:org.eclipse.persistence.jpa') {
+    implementation('org.springframework.boot:spring-boot-starter-data-jpa')
+    implementation('org.eclipse.persistence:org.eclipse.persistence.jpa') {
         exclude group: 'org.eclipse.persistence', module: 'jakarta.persistence'
     }
     testImplementation('org.springframework.boot:spring-boot-starter-test')

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlApplyChargeToOverdueLoansBusinessStep.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlApplyChargeToOverdueLoansBusinessStep.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.cob.loan.LoanCOBBusinessStep;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.organisation.holiday.domain.Holiday;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.OverdueLoanScheduleData;
+import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
+
+/**
+ * Replaces the upstream "apply charge to overdue loans" step so that the {@code penaltyWaitPeriod} configuration is
+ * counted in working days. Same {@link #getEnumStyledName()} as upstream — {@code COBBusinessStepServiceImpl} prefers
+ * {@code @Primary} beans when multiple implementations share an enum name. Wired in {@link MnzlGraceConfiguration}.
+ */
+@RequiredArgsConstructor
+public class MnzlApplyChargeToOverdueLoansBusinessStep implements LoanCOBBusinessStep {
+
+    private final ConfigurationDomainService configurationDomainService;
+    private final LoanChargeWritePlatformService loanChargeWritePlatformService;
+    private final MnzlWorkingDayCalculator workingDayCalculator;
+
+    @Override
+    public Loan execute(Loan loan) {
+        if (!loan.isOpen()) {
+            return loan;
+        }
+        Optional<Charge> optPenaltyCharge = loan.getLoanProduct().getCharges().stream()
+                .filter(c -> ChargeTimeType.OVERDUE_INSTALLMENT.getValue().equals(c.getChargeTimeType()) && c.isLoanCharge()).findFirst();
+        if (optPenaltyCharge.isEmpty()) {
+            return loan;
+        }
+        final Charge penaltyCharge = optPenaltyCharge.get();
+        final Long penaltyWaitPeriod = configurationDomainService.retrievePenaltyWaitPeriod();
+        final boolean backdatePenalties = configurationDomainService.isBackdatePenaltiesEnabled();
+        final LocalDate businessDate = DateUtils.getBusinessLocalDate();
+        final Long officeId = loan.getOffice() != null ? loan.getOffice().getId() : null;
+        // Hoist working-days config + holiday list once per loan; the per-installment loop reuses them.
+        final WorkingDays workingDays = workingDayCalculator.getWorkingDays();
+        // Holidays may sit either before or after the business date depending on which installment is in scope, so
+        // anchor the lookup at the earliest possible due date in the schedule.
+        final LocalDate earliestDueDate = loan.getRepaymentScheduleInstallments().stream().map(LoanRepaymentScheduleInstallment::getDueDate)
+                .min(LocalDate::compareTo).orElse(businessDate);
+        final List<Holiday> holidays = workingDayCalculator.getActiveHolidaysForOffice(officeId, earliestDueDate);
+        final int penaltyWaitPeriodDays = penaltyWaitPeriod == null ? 0 : Math.toIntExact(penaltyWaitPeriod);
+
+        List<OverdueLoanScheduleData> overdueList = new ArrayList<>();
+        for (LoanRepaymentScheduleInstallment installment : loan.getRepaymentScheduleInstallments()) {
+            if (installment.isObligationsMet() || installment.isRecalculatedInterestComponent()) {
+                continue;
+            }
+            // First calendar date on which the penalty is due, after `penaltyWaitPeriod` working days of grace.
+            LocalDate firstPenaltyDate = workingDayCalculator.addWorkingDays(installment.getDueDate(), penaltyWaitPeriodDays, workingDays,
+                    holidays);
+            boolean isPenaltyDue = !businessDate.isBefore(firstPenaltyDate);
+            boolean isFirstPenaltyDay = businessDate.equals(firstPenaltyDate);
+            if (!isPenaltyDue) {
+                continue;
+            }
+            if (!backdatePenalties && !isFirstPenaltyDay) {
+                continue;
+            }
+            overdueList.add(new OverdueLoanScheduleData(loan.getId(), penaltyCharge.getId(),
+                    DateUtils.DEFAULT_DATE_FORMATTER.format(installment.getDueDate()), penaltyCharge.getAmount(),
+                    DateUtils.DEFAULT_DATE_FORMAT, Locale.ENGLISH.toLanguageTag(),
+                    installment.getPrincipalOutstanding(loan.getCurrency()).getAmount(),
+                    installment.getInterestOutstanding(loan.getCurrency()).getAmount(), installment.getInstallmentNumber()));
+        }
+        if (!overdueList.isEmpty()) {
+            loanChargeWritePlatformService.applyOverdueChargesForLoan(loan.getId(), overdueList);
+        }
+        return loan;
+    }
+
+    @Override
+    public String getEnumStyledName() {
+        return "APPLY_CHARGE_TO_OVERDUE_LOANS";
+    }
+
+    @Override
+    public String getHumanReadableName() {
+        return "Apply charge to overdue loans";
+    }
+}

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStep.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStep.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.cob.loan.LoanCOBBusinessStep;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.event.business.domain.loan.repayment.LoanRepaymentOverdueBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.organisation.holiday.domain.Holiday;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+
+/**
+ * Replaces the upstream "check loan repayment overdue" step so that the configured "days after due date to raise event"
+ * count is interpreted as working days (skipping weekends and active holidays for the loan's office). Same
+ * {@link #getEnumStyledName()} as upstream — {@code COBBusinessStepServiceImpl} prefers {@code @Primary} beans when
+ * multiple implementations share an enum name. Wired in {@link MnzlGraceConfiguration}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class MnzlCheckLoanRepaymentOverdueBusinessStep implements LoanCOBBusinessStep {
+
+    private final ConfigurationDomainService configurationDomainService;
+    private final BusinessEventNotifierService businessEventNotifierService;
+    private final MnzlWorkingDayCalculator workingDayCalculator;
+
+    @Override
+    public Loan execute(Loan loan) {
+        List<LoanStatus> nonDisbursedStatuses = Arrays.asList(LoanStatus.INVALID, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL,
+                LoanStatus.APPROVED);
+        if (nonDisbursedStatuses.contains(loan.getStatus()) || loan.getSummary().getTotalOutstanding().compareTo(BigDecimal.ZERO) <= 0) {
+            return loan;
+        }
+        log.debug("start processing loan repayment overdue business step (working-day grace) for loan with Id [{}]", loan.getId());
+        Long numberOfDaysAfterDueDateToRaiseEvent = configurationDomainService.retrieveRepaymentOverdueDays();
+        if (loan.getLoanProduct().getOverDueDaysForRepaymentEvent() != null
+                && loan.getLoanProduct().getOverDueDaysForRepaymentEvent() > 0) {
+            numberOfDaysAfterDueDateToRaiseEvent = loan.getLoanProduct().getOverDueDaysForRepaymentEvent().longValue();
+        }
+        final LocalDate currentDate = DateUtils.getBusinessLocalDate();
+        final Long officeId = loan.getOffice() != null ? loan.getOffice().getId() : null;
+        // Hoist working-days config + holiday list once per loan; the per-installment loop reuses them.
+        final WorkingDays workingDays = workingDayCalculator.getWorkingDays();
+        final List<Holiday> holidays = workingDayCalculator.getActiveHolidaysForOffice(officeId, currentDate);
+        for (LoanRepaymentScheduleInstallment installment : loan.getRepaymentScheduleInstallments()) {
+            if (installment.isObligationsMet()) {
+                continue;
+            }
+            LocalDate triggerDate = computeTriggerDate(installment.getDueDate(), numberOfDaysAfterDueDateToRaiseEvent, workingDays,
+                    holidays);
+            if (triggerDate.equals(currentDate) && installment.getTotalOutstanding(loan.getCurrency()).isGreaterThanZero()) {
+                businessEventNotifierService.notifyPostBusinessEvent(new LoanRepaymentOverdueBusinessEvent(installment));
+                break;
+            }
+        }
+        log.debug("end processing loan repayment overdue business step (working-day grace) for loan with Id [{}]", loan.getId());
+        return loan;
+    }
+
+    private LocalDate computeTriggerDate(LocalDate dueDate, Long offsetDays, WorkingDays workingDays, List<Holiday> holidays) {
+        // Negative offsets ("raise event N days BEFORE due date") aren't expressible as a working-day shift; preserve
+        // upstream calendar behaviour for that case so we don't silently change semantics.
+        if (offsetDays == null || offsetDays < 0) {
+            return dueDate.plusDays(offsetDays == null ? 0L : offsetDays);
+        }
+        return workingDayCalculator.addWorkingDays(dueDate, Math.toIntExact(offsetDays), workingDays, holidays);
+    }
+
+    @Override
+    public String getEnumStyledName() {
+        return "CHECK_LOAN_REPAYMENT_OVERDUE";
+    }
+
+    @Override
+    public String getHumanReadableName() {
+        return "Check loan repayment overdue";
+    }
+}

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStep.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStep.java
@@ -65,8 +65,13 @@ public class MnzlCheckLoanRepaymentOverdueBusinessStep implements LoanCOBBusines
         final LocalDate currentDate = DateUtils.getBusinessLocalDate();
         final Long officeId = loan.getOffice() != null ? loan.getOffice().getId() : null;
         // Hoist working-days config + holiday list once per loan; the per-installment loop reuses them.
+        // Anchor the holiday lookup at the earliest unmet due date (not currentDate) — addWorkingDays iterates
+        // forward from each installment's dueDate, which is typically before currentDate, and
+        // findByOfficeIdAndGreaterThanDate excludes anything <= the anchor.
         final WorkingDays workingDays = workingDayCalculator.getWorkingDays();
-        final List<Holiday> holidays = workingDayCalculator.getActiveHolidaysForOffice(officeId, currentDate);
+        final LocalDate earliestUnmetDueDate = loan.getRepaymentScheduleInstallments().stream().filter(i -> !i.isObligationsMet())
+                .map(LoanRepaymentScheduleInstallment::getDueDate).min(LocalDate::compareTo).orElse(currentDate);
+        final List<Holiday> holidays = workingDayCalculator.getActiveHolidaysForOffice(officeId, earliestUnmetDueDate);
         for (LoanRepaymentScheduleInstallment installment : loan.getRepaymentScheduleInstallments()) {
             if (installment.isObligationsMet()) {
                 continue;

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlGraceConfiguration.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlGraceConfiguration.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import org.apache.fineract.cob.loan.LoanCOBBusinessStep;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
+import org.apache.fineract.portfolio.delinquency.helper.DelinquencyEffectivePauseHelper;
+import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainService;
+import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainServiceImpl;
+import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
+import org.apache.fineract.portfolio.loanaccount.service.LoanTransactionReadService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@ConditionalOnProperty(name = "mnzl.loan.grace.workingDays.enabled", havingValue = "true", matchIfMissing = true)
+public class MnzlGraceConfiguration {
+
+    @Bean
+    public MnzlWorkingDayCalculator mnzlWorkingDayCalculator(WorkingDaysRepositoryWrapper workingDaysRepository,
+            HolidayRepositoryWrapper holidayRepository) {
+        return new MnzlWorkingDayCalculator(workingDaysRepository, holidayRepository);
+    }
+
+    @Bean
+    @Primary
+    public LoanDelinquencyDomainService mnzlLoanDelinquencyDomainService(DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper,
+            LoanTransactionReadService loanTransactionReadService, MnzlWorkingDayCalculator workingDayCalculator) {
+        // Upstream DelinquencyConfiguration declares its loanDelinquencyDomainService bean as
+        // @ConditionalOnMissingBean(LoanDelinquencyDomainService.class) — registering our bean disables theirs,
+        // so we have to construct the delegate directly. If the upstream constructor signature ever changes,
+        // this call breaks at compile time.
+        LoanDelinquencyDomainService delegate = new LoanDelinquencyDomainServiceImpl(delinquencyEffectivePauseHelper,
+                loanTransactionReadService);
+        return new MnzlLoanDelinquencyDomainService(delegate, workingDayCalculator);
+    }
+
+    @Bean
+    @Primary
+    public LoanCOBBusinessStep mnzlCheckLoanRepaymentOverdueBusinessStep(ConfigurationDomainService configurationDomainService,
+            BusinessEventNotifierService businessEventNotifierService, MnzlWorkingDayCalculator workingDayCalculator) {
+        return new MnzlCheckLoanRepaymentOverdueBusinessStep(configurationDomainService, businessEventNotifierService,
+                workingDayCalculator);
+    }
+
+    @Bean
+    @Primary
+    public LoanCOBBusinessStep mnzlApplyChargeToOverdueLoansBusinessStep(ConfigurationDomainService configurationDomainService,
+            LoanChargeWritePlatformService loanChargeWritePlatformService, MnzlWorkingDayCalculator workingDayCalculator) {
+        return new MnzlApplyChargeToOverdueLoansBusinessStep(configurationDomainService, loanChargeWritePlatformService,
+                workingDayCalculator);
+    }
+}

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlLoanDelinquencyDomainService.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlLoanDelinquencyDomainService.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainService;
 import org.apache.fineract.portfolio.delinquency.validator.LoanDelinquencyActionData;
 import org.apache.fineract.portfolio.loanaccount.data.CollectionData;
@@ -34,6 +35,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.Loan;
  * {@code delinquentDate} (push later by the extra weekend/holiday days) and {@code delinquentDays} (subtract the same
  * offset, clamped at zero).
  */
+@Slf4j
 @RequiredArgsConstructor
 public class MnzlLoanDelinquencyDomainService implements LoanDelinquencyDomainService {
 
@@ -80,8 +82,17 @@ public class MnzlLoanDelinquencyDomainService implements LoanDelinquencyDomainSe
         // would leak the mutation back to the cache.
         data.setDelinquentDate(workingDelinquentDate);
         Long currentDelinquentDays = data.getDelinquentDays();
+        Long adjustedDelinquentDays = currentDelinquentDays;
         if (currentDelinquentDays != null && currentDelinquentDays > 0) {
-            data.setDelinquentDays(Math.max(0L, currentDelinquentDays - extraGraceDays));
+            adjustedDelinquentDays = Math.max(0L, currentDelinquentDays - extraGraceDays);
+            data.setDelinquentDays(adjustedDelinquentDays);
         }
+        // Audit trail so ops can explain "why is this loan's delinquentDate later than I expected" without code
+        // spelunking.
+        log.info(
+                "Working-day grace shifted delinquency for loan id [{}]: delinquentDate {} -> {} (+{} calendar days for weekends/holidays), "
+                        + "delinquentDays {} -> {} (graceOnArrearsAgeing={} working days)",
+                loan.getId(), calendarDelinquentDate, workingDelinquentDate, extraGraceDays, currentDelinquentDays, adjustedDelinquentDays,
+                graceDays);
     }
 }

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlLoanDelinquencyDomainService.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlLoanDelinquencyDomainService.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainService;
+import org.apache.fineract.portfolio.delinquency.validator.LoanDelinquencyActionData;
+import org.apache.fineract.portfolio.loanaccount.data.CollectionData;
+import org.apache.fineract.portfolio.loanaccount.data.LoanDelinquencyData;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+
+/**
+ * Decorator over the upstream {@link LoanDelinquencyDomainService} that reinterprets {@code graceOnArrearsAgeing} as
+ * working days. The delegate computes everything assuming calendar-day grace; this wrapper post-corrects
+ * {@code delinquentDate} (push later by the extra weekend/holiday days) and {@code delinquentDays} (subtract the same
+ * offset, clamped at zero).
+ */
+@RequiredArgsConstructor
+public class MnzlLoanDelinquencyDomainService implements LoanDelinquencyDomainService {
+
+    private final LoanDelinquencyDomainService delegate;
+    private final MnzlWorkingDayCalculator workingDayCalculator;
+
+    @Override
+    public CollectionData getOverdueCollectionData(Loan loan, List<LoanDelinquencyActionData> effectiveDelinquencyList) {
+        CollectionData base = delegate.getOverdueCollectionData(loan, effectiveDelinquencyList);
+        adjustForWorkingDayGrace(loan, base);
+        return base;
+    }
+
+    @Override
+    public LoanDelinquencyData getLoanDelinquencyData(Loan loan, List<LoanDelinquencyActionData> effectiveDelinquencyList) {
+        LoanDelinquencyData base = delegate.getLoanDelinquencyData(loan, effectiveDelinquencyList);
+        adjustForWorkingDayGrace(loan, base.getLoanCollectionData());
+        return base;
+    }
+
+    private void adjustForWorkingDayGrace(Loan loan, CollectionData data) {
+        if (data == null || data.getDelinquentDate() == null) {
+            return;
+        }
+        Integer graceDays = loan.getLoanProductRelatedDetail().getGraceOnArrearsAgeing();
+        if (graceDays == null || graceDays <= 0) {
+            return;
+        }
+        // Reverse-derive overdueSinceDate from the delegate's output. This relies on upstream
+        // LoanDelinquencyDomainServiceImpl computing delinquentDate = overdueSinceDate.plusDays(graceDays)
+        // (see lines 129 and 208 in that class); if that formula ever changes, this wrapper silently
+        // produces wrong dates with no compile-time signal.
+        Long officeId = loan.getOffice() != null ? loan.getOffice().getId() : null;
+        LocalDate calendarDelinquentDate = data.getDelinquentDate();
+        LocalDate overdueSinceDate = calendarDelinquentDate.minusDays(graceDays);
+        LocalDate workingDelinquentDate = workingDayCalculator.addWorkingDays(overdueSinceDate, graceDays, officeId);
+
+        long extraGraceDays = ChronoUnit.DAYS.between(calendarDelinquentDate, workingDelinquentDate);
+        if (extraGraceDays <= 0) {
+            return;
+        }
+        // Mutates the delegate's CollectionData in place. Safe today because the delegate constructs a fresh
+        // CollectionData.template() per call and returns it; if that ever changes (e.g. caching), this wrapper
+        // would leak the mutation back to the cache.
+        data.setDelinquentDate(workingDelinquentDate);
+        Long currentDelinquentDays = data.getDelinquentDays();
+        if (currentDelinquentDays != null && currentDelinquentDays > 0) {
+            data.setDelinquentDays(Math.max(0L, currentDelinquentDays - extraGraceDays));
+        }
+    }
+}

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculator.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculator.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.organisation.holiday.domain.Holiday;
+import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
+import org.apache.fineract.organisation.holiday.service.HolidayUtil;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
+import org.apache.fineract.organisation.workingdays.service.WorkingDaysUtil;
+
+/**
+ * Counts grace periods in working days, skipping non-working days per the global {@code m_working_days} RRULE and
+ * active per-office entries in {@code m_holiday}. Holiday rescheduling semantics are intentionally ignored — the
+ * holiday list is consumed only as a "skip these dates" calendar.
+ *
+ * <p>
+ * Two flavours of {@link #addWorkingDays}: a convenience form that fetches working-days config and per-office holidays
+ * from the database on every call, and a pre-fetched form for hot loops where the caller has already loaded both.
+ * </p>
+ */
+@RequiredArgsConstructor
+public class MnzlWorkingDayCalculator {
+
+    private final WorkingDaysRepositoryWrapper workingDaysRepository;
+    private final HolidayRepositoryWrapper holidayRepository;
+
+    /**
+     * Returns the calendar date that is {@code workingDays} working days after {@code start}. The {@code start} date
+     * itself is never counted, regardless of whether it is a working day. Fetches working-days config and the office's
+     * holiday list on every call — prefer {@link #addWorkingDays(LocalDate, int, WorkingDays, List)} when calling in a
+     * loop.
+     */
+    public LocalDate addWorkingDays(LocalDate start, int workingDays, Long officeId) {
+        if (start == null || workingDays <= 0) {
+            return start;
+        }
+        return addWorkingDays(start, workingDays, getWorkingDays(), getActiveHolidaysForOffice(officeId, start));
+    }
+
+    /**
+     * Pre-fetched-context variant of {@link #addWorkingDays(LocalDate, int, Long)}. Hoist the {@code WorkingDays} and
+     * {@code holidays} lookups outside loops to avoid repeated DB hits.
+     */
+    public LocalDate addWorkingDays(LocalDate start, int workingDays, WorkingDays config, List<Holiday> holidays) {
+        if (start == null || workingDays <= 0) {
+            return start;
+        }
+        LocalDate cursor = start;
+        int counted = 0;
+        while (counted < workingDays) {
+            cursor = cursor.plusDays(1);
+            if (isWorkingDay(cursor, config, holidays)) {
+                counted++;
+            }
+        }
+        return cursor;
+    }
+
+    /**
+     * Calendar-day distance between {@code start} and {@code start + workingDays} working days. Useful when an upstream
+     * calculation expects an integer day count.
+     */
+    public int workingDaysToCalendarDays(LocalDate start, int workingDays, Long officeId) {
+        LocalDate end = addWorkingDays(start, workingDays, officeId);
+        return (int) ChronoUnit.DAYS.between(start, end);
+    }
+
+    public boolean isWorkingDay(LocalDate date, Long officeId) {
+        return isWorkingDay(date, getWorkingDays(), getActiveHolidaysForOffice(officeId, date));
+    }
+
+    /** Loads the global {@code m_working_days} config. Exposed so callers can hoist outside loops. */
+    public WorkingDays getWorkingDays() {
+        return workingDaysRepository.findOne();
+    }
+
+    /**
+     * Active holidays for {@code officeId} occurring on or after {@code from}. Returns an empty list when
+     * {@code officeId} is {@code null}. Exposed so callers can hoist outside loops.
+     */
+    public List<Holiday> getActiveHolidaysForOffice(Long officeId, LocalDate from) {
+        if (officeId == null) {
+            return Collections.emptyList();
+        }
+        return holidayRepository.findByOfficeIdAndGreaterThanDate(officeId, from);
+    }
+
+    private boolean isWorkingDay(LocalDate date, WorkingDays config, List<Holiday> holidays) {
+        return WorkingDaysUtil.isWorkingDay(config, date) && !HolidayUtil.isHoliday(date, holidays);
+    }
+}

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculator.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculator.java
@@ -67,13 +67,21 @@ public class MnzlWorkingDayCalculator {
         if (start == null || workingDays <= 0) {
             return start;
         }
+        // Safety cap. With a healthy RRULE (>=1 working day per week) and reasonable holiday density, advancing
+        // N working days takes at most ~N*7/5 calendar days; the buffer covers long holiday runs. If the RRULE
+        // is misconfigured (e.g. no working days), this prevents the COB thread from hanging forever.
+        final int maxIterations = workingDays * 7 + 14;
         LocalDate cursor = start;
         int counted = 0;
-        while (counted < workingDays) {
+        for (int i = 0; i < maxIterations && counted < workingDays; i++) {
             cursor = cursor.plusDays(1);
             if (isWorkingDay(cursor, config, holidays)) {
                 counted++;
             }
+        }
+        if (counted < workingDays) {
+            throw new IllegalStateException("Could not advance " + workingDays + " working days from " + start + " within " + maxIterations
+                    + " iterations — check m_working_days RRULE and m_holiday entries (RRULE was: " + config.getRecurrence() + ")");
         }
         return cursor;
     }

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlApplyChargeToOverdueLoansBusinessStepTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlApplyChargeToOverdueLoansBusinessStepTest.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.organisation.workingdays.domain.RepaymentRescheduleType;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MnzlApplyChargeToOverdueLoansBusinessStepTest {
+
+    private static final long LOAN_ID = 42L;
+    private static final long OFFICE_ID = 7L;
+    private static final long PENALTY_CHARGE_ID = 99L;
+    private static final LocalDate DUE_DATE = LocalDate.of(2025, 1, 5);
+    private static final WorkingDays WORKING_DAYS = new WorkingDays("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH",
+            RepaymentRescheduleType.SAME_DAY.getValue(), false, false);
+
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private LoanChargeWritePlatformService loanChargeWritePlatformService;
+    @Mock
+    private MnzlWorkingDayCalculator workingDayCalculator;
+    @Mock
+    private Loan loan;
+    @Mock
+    private LoanProduct loanProduct;
+    @Mock
+    private Office office;
+    @Mock
+    private Charge penaltyCharge;
+    @Mock
+    private LoanRepaymentScheduleInstallment installment;
+    @Mock
+    private MonetaryCurrency currency;
+    @Mock
+    private Money zeroMoney;
+
+    private MnzlApplyChargeToOverdueLoansBusinessStep step;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null));
+        step = new MnzlApplyChargeToOverdueLoansBusinessStep(configurationDomainService, loanChargeWritePlatformService,
+                workingDayCalculator);
+
+        when(loan.isOpen()).thenReturn(true);
+        when(loan.getId()).thenReturn(LOAN_ID);
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loan.getOffice()).thenReturn(office);
+        when(office.getId()).thenReturn(OFFICE_ID);
+        when(loan.getCurrency()).thenReturn(currency);
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(installment));
+        when(installment.isObligationsMet()).thenReturn(false);
+        when(installment.isRecalculatedInterestComponent()).thenReturn(false);
+        when(installment.getDueDate()).thenReturn(DUE_DATE);
+        when(installment.getInstallmentNumber()).thenReturn(1);
+        when(installment.getPrincipalOutstanding(currency)).thenReturn(zeroMoney);
+        when(installment.getInterestOutstanding(currency)).thenReturn(zeroMoney);
+        when(zeroMoney.getAmount()).thenReturn(BigDecimal.ZERO);
+
+        when(loanProduct.getCharges()).thenReturn(List.of(penaltyCharge));
+        when(penaltyCharge.getChargeTimeType()).thenReturn(ChargeTimeType.OVERDUE_INSTALLMENT.getValue());
+        when(penaltyCharge.isLoanCharge()).thenReturn(true);
+        when(penaltyCharge.getId()).thenReturn(PENALTY_CHARGE_ID);
+        when(penaltyCharge.getAmount()).thenReturn(BigDecimal.valueOf(50));
+
+        when(configurationDomainService.retrievePenaltyWaitPeriod()).thenReturn(5L);
+        when(configurationDomainService.isBackdatePenaltiesEnabled()).thenReturn(false);
+        when(workingDayCalculator.getWorkingDays()).thenReturn(WORKING_DAYS);
+        when(workingDayCalculator.getActiveHolidaysForOffice(eq(OFFICE_ID), any())).thenReturn(List.of());
+    }
+
+    @Test
+    void appliesPenaltyOnTheFirstWorkingDayPastGrace() {
+        LocalDate firstPenaltyDate = LocalDate.of(2025, 1, 13); // 5 working days from Sun 2025-01-05.
+        setBusinessDate(firstPenaltyDate);
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(firstPenaltyDate);
+
+        step.execute(loan);
+
+        verify(loanChargeWritePlatformService).applyOverdueChargesForLoan(eq(LOAN_ID), argThat(list -> list.size() == 1));
+    }
+
+    @Test
+    void doesNotApplyPenaltyWhileStillInWorkingDayGrace() {
+        // Calendar grace would have expired (5 calendar days from due) but only 3 working days have passed.
+        LocalDate stillInGrace = LocalDate.of(2025, 1, 10);
+        setBusinessDate(stillInGrace);
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2025, 1, 13));
+
+        step.execute(loan);
+
+        verify(loanChargeWritePlatformService, never()).applyOverdueChargesForLoan(anyLong(), any());
+    }
+
+    @Test
+    void skipsLaterDaysWhenBackdatePenaltiesIsDisabled() {
+        // backdate=false: penalty fires only on the first day. On day-2 past grace, do nothing.
+        LocalDate dayAfterFirstPenalty = LocalDate.of(2025, 1, 14);
+        setBusinessDate(dayAfterFirstPenalty);
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2025, 1, 13));
+
+        step.execute(loan);
+
+        verify(loanChargeWritePlatformService, never()).applyOverdueChargesForLoan(anyLong(), any());
+    }
+
+    @Test
+    void appliesOnLaterDaysWhenBackdatePenaltiesIsEnabled() {
+        when(configurationDomainService.isBackdatePenaltiesEnabled()).thenReturn(true);
+        LocalDate dayAfterFirstPenalty = LocalDate.of(2025, 1, 14);
+        setBusinessDate(dayAfterFirstPenalty);
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2025, 1, 13));
+
+        step.execute(loan);
+
+        verify(loanChargeWritePlatformService).applyOverdueChargesForLoan(eq(LOAN_ID), argThat(list -> list.size() == 1));
+    }
+
+    @Test
+    void noopWhenLoanProductHasNoOverduePenaltyCharge() {
+        setBusinessDate(LocalDate.of(2025, 1, 13));
+        when(loanProduct.getCharges()).thenReturn(List.of());
+
+        step.execute(loan);
+
+        verify(loanChargeWritePlatformService, never()).applyOverdueChargesForLoan(anyLong(), any());
+    }
+
+    @Test
+    void noopForClosedLoans() {
+        setBusinessDate(LocalDate.of(2025, 1, 13));
+        when(loan.isOpen()).thenReturn(false);
+
+        step.execute(loan);
+
+        verify(loanChargeWritePlatformService, never()).applyOverdueChargesForLoan(anyLong(), any());
+    }
+
+    private static void setBusinessDate(LocalDate date) {
+        HashMap<BusinessDateType, LocalDate> dates = new HashMap<>();
+        dates.put(BusinessDateType.BUSINESS_DATE, date);
+        dates.put(BusinessDateType.COB_DATE, date.minusDays(1));
+        ThreadLocalContextUtil.setBusinessDates(dates);
+    }
+}

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStepTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStepTest.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.event.business.domain.loan.repayment.LoanRepaymentOverdueBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.organisation.workingdays.domain.RepaymentRescheduleType;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanSummary;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MnzlCheckLoanRepaymentOverdueBusinessStepTest {
+
+    private static final long OFFICE_ID = 7L;
+    private static final LocalDate DUE_DATE = LocalDate.of(2025, 1, 5);
+    private static final WorkingDays WORKING_DAYS = new WorkingDays("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH",
+            RepaymentRescheduleType.SAME_DAY.getValue(), false, false);
+
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private BusinessEventNotifierService businessEventNotifierService;
+    @Mock
+    private MnzlWorkingDayCalculator workingDayCalculator;
+    @Mock
+    private Loan loan;
+    @Mock
+    private LoanProduct loanProduct;
+    @Mock
+    private LoanSummary loanSummary;
+    @Mock
+    private Office office;
+    @Mock
+    private LoanRepaymentScheduleInstallment installment;
+    @Mock
+    private MonetaryCurrency currency;
+
+    private MnzlCheckLoanRepaymentOverdueBusinessStep step;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null));
+        step = new MnzlCheckLoanRepaymentOverdueBusinessStep(configurationDomainService, businessEventNotifierService,
+                workingDayCalculator);
+
+        when(loan.getStatus()).thenReturn(LoanStatus.ACTIVE);
+        when(loan.getSummary()).thenReturn(loanSummary);
+        when(loanSummary.getTotalOutstanding()).thenReturn(BigDecimal.valueOf(100));
+        when(loan.getLoanProduct()).thenReturn(loanProduct);
+        when(loanProduct.getOverDueDaysForRepaymentEvent()).thenReturn(null);
+        when(loan.getOffice()).thenReturn(office);
+        when(office.getId()).thenReturn(OFFICE_ID);
+        when(loan.getCurrency()).thenReturn(currency);
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(installment));
+        when(installment.isObligationsMet()).thenReturn(false);
+        when(installment.getDueDate()).thenReturn(DUE_DATE);
+        when(configurationDomainService.retrieveRepaymentOverdueDays()).thenReturn(5L);
+        when(workingDayCalculator.getWorkingDays()).thenReturn(WORKING_DAYS);
+        when(workingDayCalculator.getActiveHolidaysForOffice(eq(OFFICE_ID), any())).thenReturn(List.of());
+    }
+
+    @Test
+    void firesOverdueEventOnTheWorkingDayTrigger() {
+        LocalDate businessDate = LocalDate.of(2025, 1, 12); // 5 working days after Sunday 2025-01-05.
+        setBusinessDate(businessDate);
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(businessDate);
+        Money outstanding = positiveMoney();
+        when(installment.getTotalOutstanding(currency)).thenReturn(outstanding);
+
+        step.execute(loan);
+
+        verify(businessEventNotifierService).notifyPostBusinessEvent(any(LoanRepaymentOverdueBusinessEvent.class));
+    }
+
+    @Test
+    void doesNotFireBeforeWorkingDayTriggerEvenIfCalendarGraceHasElapsed() {
+        LocalDate businessDate = LocalDate.of(2025, 1, 10); // 5 calendar days, but only 3 working days have passed.
+        setBusinessDate(businessDate);
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2025, 1, 12));
+
+        step.execute(loan);
+
+        verify(businessEventNotifierService, never()).notifyPostBusinessEvent(any());
+    }
+
+    @Test
+    void skipsObligationsMetInstallments() {
+        setBusinessDate(LocalDate.of(2025, 1, 12));
+        when(installment.isObligationsMet()).thenReturn(true);
+
+        step.execute(loan);
+
+        verify(businessEventNotifierService, never()).notifyPostBusinessEvent(any());
+        verify(workingDayCalculator, never()).addWorkingDays(any(), anyInt(), any(), any());
+    }
+
+    @Test
+    void noopForFullyPaidLoans() {
+        setBusinessDate(LocalDate.of(2025, 1, 12));
+        when(loanSummary.getTotalOutstanding()).thenReturn(BigDecimal.ZERO);
+
+        step.execute(loan);
+
+        verify(businessEventNotifierService, never()).notifyPostBusinessEvent(any());
+    }
+
+    @Test
+    void negativeOffsetFallsBackToCalendarArithmetic() {
+        // Upstream supports "raise event N days BEFORE due"; preserve that for negative configs.
+        LocalDate businessDate = LocalDate.of(2025, 1, 3); // due 2025-01-05 minus 2 calendar days
+        setBusinessDate(businessDate);
+        when(configurationDomainService.retrieveRepaymentOverdueDays()).thenReturn(-2L);
+        Money outstanding = positiveMoney();
+        when(installment.getTotalOutstanding(currency)).thenReturn(outstanding);
+
+        step.execute(loan);
+
+        verify(businessEventNotifierService).notifyPostBusinessEvent(any(LoanRepaymentOverdueBusinessEvent.class));
+        verify(workingDayCalculator, never()).addWorkingDays(any(LocalDate.class), anyInt(), any(WorkingDays.class), any());
+    }
+
+    private static void setBusinessDate(LocalDate date) {
+        HashMap<BusinessDateType, LocalDate> dates = new HashMap<>();
+        dates.put(BusinessDateType.BUSINESS_DATE, date);
+        dates.put(BusinessDateType.COB_DATE, date.minusDays(1));
+        ThreadLocalContextUtil.setBusinessDates(dates);
+    }
+
+    private static Money positiveMoney() {
+        Money money = mock(Money.class);
+        when(money.isGreaterThanZero()).thenReturn(true);
+        return money;
+    }
+}

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStepTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlCheckLoanRepaymentOverdueBusinessStepTest.java
@@ -152,6 +152,20 @@ class MnzlCheckLoanRepaymentOverdueBusinessStepTest {
     }
 
     @Test
+    void anchorsHolidayLookupAtEarliestUnmetDueDateNotBusinessDate() {
+        // Holiday Jan 8 sits between the installment due date (Jan 5) and today (Jan 12). Anchoring at currentDate
+        // would miss it; anchor at the earliest unmet due date so addWorkingDays sees it.
+        setBusinessDate(LocalDate.of(2025, 1, 12));
+        // Stub addWorkingDays to a non-null value so the rest of the loop doesn't NPE; the assertion below is
+        // about the anchor passed to getActiveHolidaysForOffice.
+        when(workingDayCalculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2025, 1, 13));
+
+        step.execute(loan);
+
+        verify(workingDayCalculator).getActiveHolidaysForOffice(eq(OFFICE_ID), eq(DUE_DATE));
+    }
+
+    @Test
     void negativeOffsetFallsBackToCalendarArithmetic() {
         // Upstream supports "raise event N days BEFORE due"; preserve that for negative configs.
         LocalDate businessDate = LocalDate.of(2025, 1, 3); // due 2025-01-05 minus 2 calendar days

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlLoanDelinquencyDomainServiceTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlLoanDelinquencyDomainServiceTest.java
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainService;
+import org.apache.fineract.portfolio.loanaccount.data.CollectionData;
+import org.apache.fineract.portfolio.loanaccount.data.LoanDelinquencyData;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MnzlLoanDelinquencyDomainServiceTest {
+
+    private static final long OFFICE_ID = 7L;
+
+    @Mock
+    private LoanDelinquencyDomainService delegate;
+    @Mock
+    private MnzlWorkingDayCalculator workingDayCalculator;
+    @Mock
+    private Loan loan;
+    @Mock
+    private Office office;
+    @Mock
+    private LoanProductRelatedDetail productDetail;
+
+    private MnzlLoanDelinquencyDomainService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MnzlLoanDelinquencyDomainService(delegate, workingDayCalculator);
+        when(loan.getLoanProductRelatedDetail()).thenReturn(productDetail);
+        when(loan.getOffice()).thenReturn(office);
+        when(office.getId()).thenReturn(OFFICE_ID);
+    }
+
+    @Test
+    void noGraceConfiguredLeavesDelegateOutputUnchanged() {
+        when(productDetail.getGraceOnArrearsAgeing()).thenReturn(0);
+        CollectionData base = collectionDataWith(LocalDate.of(2025, 1, 10), 5L);
+        when(delegate.getOverdueCollectionData(eq(loan), any())).thenReturn(base);
+
+        CollectionData result = service.getOverdueCollectionData(loan, Collections.emptyList());
+
+        assertThat(result.getDelinquentDate()).isEqualTo(LocalDate.of(2025, 1, 10));
+        assertThat(result.getDelinquentDays()).isEqualTo(5L);
+        verify(workingDayCalculator, never()).addWorkingDays(any(), anyInt(), any());
+    }
+
+    @Test
+    void nullDelinquentDateLeavesDelegateOutputUnchanged() {
+        CollectionData base = collectionDataWith(null, 0L);
+        when(delegate.getOverdueCollectionData(eq(loan), any())).thenReturn(base);
+
+        CollectionData result = service.getOverdueCollectionData(loan, Collections.emptyList());
+
+        assertThat(result.getDelinquentDate()).isNull();
+        verify(workingDayCalculator, never()).addWorkingDays(any(), anyInt(), any());
+    }
+
+    @Test
+    void workingDayGraceLandingOnSameDayAsCalendarLeavesOutputUnchanged() {
+        // No weekends/holidays inside the grace window — addWorkingDays returns the same date as calendar plusDays.
+        when(productDetail.getGraceOnArrearsAgeing()).thenReturn(5);
+        LocalDate calendarDelinquent = LocalDate.of(2025, 1, 15);
+        LocalDate overdueSince = LocalDate.of(2025, 1, 10);
+        CollectionData base = collectionDataWith(calendarDelinquent, 3L);
+        when(delegate.getOverdueCollectionData(eq(loan), any())).thenReturn(base);
+        when(workingDayCalculator.addWorkingDays(eq(overdueSince), eq(5), eq(OFFICE_ID))).thenReturn(calendarDelinquent);
+
+        CollectionData result = service.getOverdueCollectionData(loan, Collections.emptyList());
+
+        assertThat(result.getDelinquentDate()).isEqualTo(calendarDelinquent);
+        assertThat(result.getDelinquentDays()).isEqualTo(3L);
+    }
+
+    @Test
+    void workingDayGraceShiftsDelinquentDateForwardAndReducesDelinquentDays() {
+        when(productDetail.getGraceOnArrearsAgeing()).thenReturn(5);
+        LocalDate overdueSince = LocalDate.of(2025, 1, 5);
+        LocalDate calendarDelinquent = LocalDate.of(2025, 1, 10);
+        LocalDate workingDelinquent = LocalDate.of(2025, 1, 12); // 2 weekend days inside the window
+        CollectionData base = collectionDataWith(calendarDelinquent, 4L);
+        when(delegate.getOverdueCollectionData(eq(loan), any())).thenReturn(base);
+        when(workingDayCalculator.addWorkingDays(eq(overdueSince), eq(5), eq(OFFICE_ID))).thenReturn(workingDelinquent);
+
+        CollectionData result = service.getOverdueCollectionData(loan, Collections.emptyList());
+
+        assertThat(result.getDelinquentDate()).isEqualTo(workingDelinquent);
+        assertThat(result.getDelinquentDays()).isEqualTo(2L); // 4 calendar delinquent − 2 extra grace days = 2
+    }
+
+    @Test
+    void workingDayGraceClampsDelinquentDaysAtZero() {
+        when(productDetail.getGraceOnArrearsAgeing()).thenReturn(5);
+        LocalDate overdueSince = LocalDate.of(2025, 1, 5);
+        LocalDate calendarDelinquent = LocalDate.of(2025, 1, 10);
+        LocalDate workingDelinquent = LocalDate.of(2025, 1, 13); // 3 extra grace days
+        CollectionData base = collectionDataWith(calendarDelinquent, 1L);
+        when(delegate.getOverdueCollectionData(eq(loan), any())).thenReturn(base);
+        when(workingDayCalculator.addWorkingDays(eq(overdueSince), eq(5), eq(OFFICE_ID))).thenReturn(workingDelinquent);
+
+        CollectionData result = service.getOverdueCollectionData(loan, Collections.emptyList());
+
+        assertThat(result.getDelinquentDate()).isEqualTo(workingDelinquent);
+        assertThat(result.getDelinquentDays()).isZero();
+    }
+
+    @Test
+    void workingDayGraceLeavesZeroDelinquentDaysAtZero() {
+        when(productDetail.getGraceOnArrearsAgeing()).thenReturn(5);
+        LocalDate overdueSince = LocalDate.of(2025, 1, 5);
+        LocalDate calendarDelinquent = LocalDate.of(2025, 1, 10);
+        LocalDate workingDelinquent = LocalDate.of(2025, 1, 12);
+        CollectionData base = collectionDataWith(calendarDelinquent, 0L);
+        when(delegate.getOverdueCollectionData(eq(loan), any())).thenReturn(base);
+        when(workingDayCalculator.addWorkingDays(eq(overdueSince), eq(5), eq(OFFICE_ID))).thenReturn(workingDelinquent);
+
+        CollectionData result = service.getOverdueCollectionData(loan, Collections.emptyList());
+
+        assertThat(result.getDelinquentDate()).isEqualTo(workingDelinquent);
+        assertThat(result.getDelinquentDays()).isZero();
+    }
+
+    @Test
+    void getLoanDelinquencyDataAdjustsTheLoanCollectionData() {
+        when(productDetail.getGraceOnArrearsAgeing()).thenReturn(5);
+        LocalDate overdueSince = LocalDate.of(2025, 1, 5);
+        LocalDate calendarDelinquent = LocalDate.of(2025, 1, 10);
+        LocalDate workingDelinquent = LocalDate.of(2025, 1, 12);
+        CollectionData loanLevel = collectionDataWith(calendarDelinquent, 4L);
+        LoanDelinquencyData base = new LoanDelinquencyData(loanLevel, Collections.emptyMap());
+        when(delegate.getLoanDelinquencyData(eq(loan), any())).thenReturn(base);
+        when(workingDayCalculator.addWorkingDays(eq(overdueSince), eq(5), eq(OFFICE_ID))).thenReturn(workingDelinquent);
+
+        LoanDelinquencyData result = service.getLoanDelinquencyData(loan, Collections.emptyList());
+
+        assertThat(result.getLoanCollectionData().getDelinquentDate()).isEqualTo(workingDelinquent);
+        assertThat(result.getLoanCollectionData().getDelinquentDays()).isEqualTo(2L);
+    }
+
+    private static CollectionData collectionDataWith(LocalDate delinquentDate, Long delinquentDays) {
+        CollectionData data = CollectionData.template();
+        data.setDelinquentDate(delinquentDate);
+        data.setDelinquentDays(delinquentDays);
+        data.setDelinquentAmount(BigDecimal.ZERO);
+        return data;
+    }
+}

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculatorTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculatorTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.organisation.holiday.domain.Holiday;
+import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
+import org.apache.fineract.organisation.holiday.domain.HolidayStatusType;
+import org.apache.fineract.organisation.workingdays.domain.RepaymentRescheduleType;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MnzlWorkingDayCalculatorTest {
+
+    private static final long OFFICE_ID = 1L;
+    // Egyptian banking week: Sun-Thu working, Fri-Sat off.
+    private static final String EGYPT_RRULE = "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH";
+
+    @Mock
+    private WorkingDaysRepositoryWrapper workingDaysRepository;
+    @Mock
+    private HolidayRepositoryWrapper holidayRepository;
+
+    private MnzlWorkingDayCalculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null));
+        WorkingDays config = new WorkingDays(EGYPT_RRULE, RepaymentRescheduleType.SAME_DAY.getValue(), false, false);
+        when(workingDaysRepository.findOne()).thenReturn(config);
+        calculator = new MnzlWorkingDayCalculator(workingDaysRepository, holidayRepository);
+    }
+
+    @Test
+    void fiveWorkingDaysFromSundayWithNoHolidaysLandsOnTheFollowingSunday() {
+        LocalDate sunday = LocalDate.of(2025, 1, 5);
+        when(holidayRepository.findByOfficeIdAndGreaterThanDate(eq(OFFICE_ID), any(LocalDate.class))).thenReturn(Collections.emptyList());
+
+        LocalDate result = calculator.addWorkingDays(sunday, 5, OFFICE_ID);
+
+        assertThat(result).isEqualTo(LocalDate.of(2025, 1, 12));
+    }
+
+    @Test
+    void fiveWorkingDaysFromSundayWithMidWeekHolidayPushesOneCalendarDayFurther() {
+        LocalDate sunday = LocalDate.of(2025, 1, 5);
+        Holiday eidWednesday = activeHoliday(LocalDate.of(2025, 1, 8), LocalDate.of(2025, 1, 8));
+        when(holidayRepository.findByOfficeIdAndGreaterThanDate(eq(OFFICE_ID), any(LocalDate.class))).thenReturn(List.of(eidWednesday));
+
+        LocalDate result = calculator.addWorkingDays(sunday, 5, OFFICE_ID);
+
+        assertThat(result).isEqualTo(LocalDate.of(2025, 1, 13));
+    }
+
+    @Test
+    void fiveWorkingDaysFromFridayCountsFromTheNextSunday() {
+        LocalDate friday = LocalDate.of(2025, 1, 10);
+        when(holidayRepository.findByOfficeIdAndGreaterThanDate(eq(OFFICE_ID), any(LocalDate.class))).thenReturn(Collections.emptyList());
+
+        LocalDate result = calculator.addWorkingDays(friday, 5, OFFICE_ID);
+
+        assertThat(result).isEqualTo(LocalDate.of(2025, 1, 16));
+    }
+
+    @Test
+    void zeroWorkingDaysReturnsTheStartDate() {
+        LocalDate sunday = LocalDate.of(2025, 1, 5);
+
+        LocalDate result = calculator.addWorkingDays(sunday, 0, OFFICE_ID);
+
+        assertThat(result).isEqualTo(sunday);
+    }
+
+    @Test
+    void workingDaysToCalendarDaysReportsTheDistanceIncludingSkippedDays() {
+        LocalDate sunday = LocalDate.of(2025, 1, 5);
+        when(holidayRepository.findByOfficeIdAndGreaterThanDate(eq(OFFICE_ID), any(LocalDate.class))).thenReturn(Collections.emptyList());
+
+        int calendarDays = calculator.workingDaysToCalendarDays(sunday, 5, OFFICE_ID);
+
+        assertThat(calendarDays).isEqualTo(7);
+    }
+
+    private static Holiday activeHoliday(LocalDate from, LocalDate to) {
+        return new Holiday().setName("Test holiday " + from).setFromDate(from).setToDate(to).setStatus(HolidayStatusType.ACTIVE.getValue())
+                .setReschedulingType(0).setProcessed(false);
+    }
+}

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculatorTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlWorkingDayCalculatorTest.java
@@ -106,6 +106,18 @@ class MnzlWorkingDayCalculatorTest {
     }
 
     @Test
+    void throwsInsteadOfLoopingForeverWhenNoWorkingDayCanBeFoundInTheCap() {
+        // Pathological case: every day in the iteration window is a holiday. Without the safety cap this hangs the
+        // COB thread; with it, we throw a diagnosable error.
+        LocalDate start = LocalDate.of(2025, 1, 5);
+        WorkingDays config = new WorkingDays("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH", RepaymentRescheduleType.SAME_DAY.getValue(), false, false);
+        Holiday blanket = activeHoliday(start.plusDays(1), start.plusDays(120));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> calculator.addWorkingDays(start, 5, config, List.of(blanket)))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("m_working_days RRULE");
+    }
+
+    @Test
     void workingDaysToCalendarDaysReportsTheDistanceIncludingSkippedDays() {
         LocalDate sunday = LocalDate.of(2025, 1, 5);
         when(holidayRepository.findByOfficeIdAndGreaterThanDate(eq(OFFICE_ID), any(LocalDate.class))).thenReturn(Collections.emptyList());

--- a/custom/mnzl/loan/starter/src/test/java/co/mnzl/fineract/custom/loan/starter/CustomLoanStarterSelectionTest.java
+++ b/custom/mnzl/loan/starter/src/test/java/co/mnzl/fineract/custom/loan/starter/CustomLoanStarterSelectionTest.java
@@ -55,9 +55,9 @@ class CustomLoanStarterSelectionTest {
 
     @Test
     void customLoanStarterProvidesPrimaryCheckDueInstallmentsStep() {
-        new ApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(CustomLoanAutoConfiguration.class)).withPropertyValues("mnzl.loan.enabled=true",
-                        "mnzl.loan.job.enabled=false", "mnzl.loan.schedule.enabled=false", "mnzl.loan.instrument.enabled=false")
+        new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(CustomLoanAutoConfiguration.class))
+                .withPropertyValues("mnzl.loan.enabled=true", "mnzl.loan.job.enabled=false", "mnzl.loan.schedule.enabled=false",
+                        "mnzl.loan.instrument.enabled=false", "mnzl.loan.grace.workingDays.enabled=false")
                 .withUserConfiguration(TestConfiguration.class).run(ctx -> {
                     COBBusinessStepService businessStepService = ctx.getBean(COBBusinessStepService.class);
                     var result = businessStepService.getCOBBusinessSteps(LoanCOBBusinessStep.class, "JOB");


### PR DESCRIPTION
## Summary

- New `custom/mnzl/loan/grace` module reinterprets `graceOnArrearsAgeing`, `penaltyWaitPeriod`, and the COB overdue-event offset as **working days** instead of calendar days, so weekends and Egyptian bank holidays no longer count toward the grace window.
- Three `@Primary` decorators over upstream beans:
  - `MnzlLoanDelinquencyDomainService` post-corrects `delinquentDate` / `delinquentDays` after the upstream calendar-day computation.
  - `MnzlCheckLoanRepaymentOverdueBusinessStep` shifts when `LoanRepaymentOverdueBusinessEvent` fires.
  - `MnzlApplyChargeToOverdueLoansBusinessStep` shifts when the late-payment penalty `LoanCharge` is created.
- Working-week + holidays come from the existing `m_working_days` RRULE and per-office `m_holiday` table; operators configure both through the existing Mifos screens (`/organization/working-days`, `/organization/holidays`). No new UI, no DB migration.
- Gated by `mnzl.loan.grace.workingDays.enabled` (default `true`).

## Operator setup (post-deploy, one time)

1. Mifos → System → **Working Days**: tick Sun–Thu only (RRULE becomes `FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH`).
2. Mifos → System → **Manage Holidays**: add and **activate** Egyptian public holidays per office.
3. Confirm `graceOnArrearsAgeing` is set on the relevant loan products.
