### PR TITLE
[codex] Support negative floating-rate differentials

### DIFF
--- a/custom/mnzl/loan/schedule-api/src/test/java/co/mnzl/fineract/custom/loan/schedule/MnzlLoanTermVariationsEnricherTest.java
+++ b/custom/mnzl/loan/schedule-api/src/test/java/co/mnzl/fineract/custom/loan/schedule/MnzlLoanTermVariationsEnricherTest.java
@@ -179,6 +179,22 @@ class MnzlLoanTermVariationsEnricherTest {
         verify(floatingRateDTO).resetInterestRateDiff();
     }
 
+    @Test
+    void enrich_negativeDifferentialSurvivesResetAndContributesToApplicableRate() {
+        FloatingRateDTO dto = new FloatingRateDTO(true, TODAY.minusMonths(6), new BigDecimal("-0.25"), null);
+        dto.addInterestRateDiff(new BigDecimal("1.00"));
+        when(loanProduct.fetchInterestRates(dto)).thenAnswer(invocation -> {
+            FloatingRateDTO suppliedDto = invocation.getArgument(0);
+            assertThat(suppliedDto.getInterestRateDiff()).isEqualByComparingTo("-0.25");
+            return List.of(ratePeriod(TODAY.minusDays(10), new BigDecimal("26.00").add(suppliedDto.getInterestRateDiff())));
+        });
+
+        BigDecimal result = enricher.enrich(dto, NOMINAL_RATE, List.<LoanTermVariationsData>of(), loan);
+
+        assertThat(result).isEqualByComparingTo("25.75");
+        assertThat(dto.getInterestRateDiff()).isEqualByComparingTo("-0.25");
+    }
+
     private void stubApplicableRates(Collection<FloatingRatePeriodData> rates) {
         when(loanProduct.fetchInterestRates(floatingRateDTO)).thenReturn(rates);
     }

--- a/custom/mnzl/loan/schedule-api/src/test/java/co/mnzl/fineract/custom/loan/schedule/MnzlLoanUtilServiceTest.java
+++ b/custom/mnzl/loan/schedule-api/src/test/java/co/mnzl/fineract/custom/loan/schedule/MnzlLoanUtilServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.organisation.holiday.domain.HolidayRepository;
@@ -34,11 +35,14 @@ import org.apache.fineract.portfolio.calendar.service.CalendarReadPlatformServic
 import org.apache.fineract.portfolio.floatingrates.data.FloatingRateDTO;
 import org.apache.fineract.portfolio.floatingrates.data.FloatingRateData;
 import org.apache.fineract.portfolio.floatingrates.data.FloatingRatePeriodData;
+import org.apache.fineract.portfolio.floatingrates.domain.FloatingRate;
+import org.apache.fineract.portfolio.floatingrates.domain.FloatingRatePeriod;
 import org.apache.fineract.portfolio.floatingrates.exception.FloatingRateNotFoundException;
 import org.apache.fineract.portfolio.floatingrates.service.FloatingRatesReadPlatformService;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGeneratorFactory;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductFloatingRates;
 import org.apache.fineract.portfolio.note.domain.NoteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -157,6 +161,39 @@ class MnzlLoanUtilServiceTest {
         assertThat(dto.isFloatingInterestRate()).isTrue();
         // Base lending rate periods stay null when missing — the DTO stores whatever the override passed in.
         assertThat(dto.getBaseLendingRatePeriods()).isNull();
+    }
+
+    @Test
+    void floatingLoan_forcesFloatingDtoSoFutureRatePeriodsRemainApplicableWithNegativeDifferential() {
+        Loan loan = mock(Loan.class);
+        LoanProduct product = mock(LoanProduct.class);
+        when(loan.loanProduct()).thenReturn(product);
+        when(product.isLinkedToFloatingInterestRate()).thenReturn(true);
+        when(loan.getIsFloatingInterestRate()).thenReturn(false);
+        when(loan.getInterestRateDifferential()).thenReturn(new BigDecimal("-0.25"));
+        when(loan.getDisbursementDate()).thenReturn(LocalDate.of(2025, 1, 1));
+        FloatingRateData baseRate = mock(FloatingRateData.class);
+        when(baseRate.getRatePeriods()).thenReturn(List.of());
+        when(floatingRatesReadPlatformService.retrieveBaseLendingRate()).thenReturn(baseRate);
+
+        FloatingRateDTO dto = service.exposedConstructFloatingRateDTO(loan);
+
+        FloatingRate floatingRate = new FloatingRate("MNZL floating rate", false, true,
+                List.of(new FloatingRatePeriod(LocalDate.of(2024, 12, 1), new BigDecimal("26.00"), false, true),
+                        new FloatingRatePeriod(LocalDate.of(2025, 2, 1), new BigDecimal("27.00"), false, true)));
+        LoanProductFloatingRates productFloatingRates = new LoanProductFloatingRates(floatingRate, product, BigDecimal.ZERO,
+                new BigDecimal("-5.00"), new BigDecimal("5.00"), BigDecimal.ZERO, true);
+
+        Collection<FloatingRatePeriodData> rates = productFloatingRates.fetchInterestRates(dto);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.isFloatingInterestRate()).isTrue();
+        assertThat(dto.getInterestRateDiff()).isEqualByComparingTo("-0.25");
+        assertThat(rates).extracting(FloatingRatePeriodData::getFromDateAsLocalDate).containsExactly(LocalDate.of(2024, 12, 1),
+                LocalDate.of(2025, 2, 1));
+        assertThat(rates).extracting(FloatingRatePeriodData::getInterestRate)
+                .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                .containsExactly(new BigDecimal("25.75"), new BigDecimal("26.75"));
     }
 
     /**

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidator.java
@@ -447,7 +447,7 @@ public final class LoanApplicationValidator {
                 final BigDecimal interestRateDifferential = this.fromApiJsonHelper
                         .extractBigDecimalWithLocaleNamed(interestRateDifferentialParameterName, element);
                 baseDataValidator.reset().parameter(interestRateDifferentialParameterName).value(interestRateDifferential).notNull()
-                        .zeroOrPositiveAmount().inMinAndMaxAmountRange(loanProduct.getFloatingRates().getMinDifferentialLendingRate(),
+                        .inMinAndMaxAmountRange(loanProduct.getFloatingRates().getMinDifferentialLendingRate(),
                                 loanProduct.getFloatingRates().getMaxDifferentialLendingRate());
             } else {
 
@@ -1126,8 +1126,7 @@ public final class LoanApplicationValidator {
                     atLeastOneParameterPassedForUpdate = true;
                 }
                 baseDataValidator.reset().parameter(LoanApiConstants.interestRateDifferentialParameterName).value(interestRateDifferential)
-                        .notNull().zeroOrPositiveAmount()
-                        .inMinAndMaxAmountRange(loanProduct.getFloatingRates().getMinDifferentialLendingRate(),
+                        .notNull().inMinAndMaxAmountRange(loanProduct.getFloatingRates().getMinDifferentialLendingRate(),
                                 loanProduct.getFloatingRates().getMaxDifferentialLendingRate());
 
             } else {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidator.java
@@ -480,44 +480,25 @@ public final class LoanProductDataValidator {
 
             final BigDecimal interestRateDifferential = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(INTEREST_RATE_DIFFERENTIAL,
                     element);
-            baseDataValidator.reset().parameter(INTEREST_RATE_DIFFERENTIAL).value(interestRateDifferential).notNull()
-                    .zeroOrPositiveAmount();
+            baseDataValidator.reset().parameter(INTEREST_RATE_DIFFERENTIAL).value(interestRateDifferential).notNull();
 
             final String minDifferentialLendingRateParameterName = MIN_DIFFERENTIAL_LENDING_RATE;
             BigDecimal minDifferentialLendingRate = this.fromApiJsonHelper
                     .extractBigDecimalWithLocaleNamed(minDifferentialLendingRateParameterName, element);
-            baseDataValidator.reset().parameter(minDifferentialLendingRateParameterName).value(minDifferentialLendingRate).notNull()
-                    .zeroOrPositiveAmount();
+            baseDataValidator.reset().parameter(minDifferentialLendingRateParameterName).value(minDifferentialLendingRate).notNull();
 
             final String defaultDifferentialLendingRateParameterName = DEFAULT_DIFFERENTIAL_LENDING_RATE;
             BigDecimal defaultDifferentialLendingRate = this.fromApiJsonHelper
                     .extractBigDecimalWithLocaleNamed(defaultDifferentialLendingRateParameterName, element);
-            baseDataValidator.reset().parameter(defaultDifferentialLendingRateParameterName).value(defaultDifferentialLendingRate).notNull()
-                    .zeroOrPositiveAmount();
+            baseDataValidator.reset().parameter(defaultDifferentialLendingRateParameterName).value(defaultDifferentialLendingRate)
+                    .notNull();
 
             final String maxDifferentialLendingRateParameterName = MAX_DIFFERENTIAL_LENDING_RATE;
             BigDecimal maxDifferentialLendingRate = this.fromApiJsonHelper
                     .extractBigDecimalWithLocaleNamed(maxDifferentialLendingRateParameterName, element);
-            baseDataValidator.reset().parameter(maxDifferentialLendingRateParameterName).value(maxDifferentialLendingRate).notNull()
-                    .zeroOrPositiveAmount();
-
-            if (defaultDifferentialLendingRate != null && defaultDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0
-                    && minDifferentialLendingRate != null && minDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0) {
-                baseDataValidator.reset().parameter(DEFAULT_DIFFERENTIAL_LENDING_RATE).value(defaultDifferentialLendingRate)
-                        .notLessThanMin(minDifferentialLendingRate);
-            }
-
-            if (maxDifferentialLendingRate != null && maxDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0
-                    && minDifferentialLendingRate != null && minDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0) {
-                baseDataValidator.reset().parameter(MAX_DIFFERENTIAL_LENDING_RATE).value(maxDifferentialLendingRate)
-                        .notLessThanMin(minDifferentialLendingRate);
-            }
-
-            if (maxDifferentialLendingRate != null && maxDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0
-                    && defaultDifferentialLendingRate != null && defaultDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0) {
-                baseDataValidator.reset().parameter(MAX_DIFFERENTIAL_LENDING_RATE).value(maxDifferentialLendingRate)
-                        .notLessThanMin(defaultDifferentialLendingRate);
-            }
+            baseDataValidator.reset().parameter(maxDifferentialLendingRateParameterName).value(maxDifferentialLendingRate).notNull();
+            validateFloatingRateDifferentialBounds(baseDataValidator, interestRateDifferential, minDifferentialLendingRate,
+                    defaultDifferentialLendingRate, maxDifferentialLendingRate);
 
             final Boolean isFloatingInterestRateCalculationAllowed = this.fromApiJsonHelper
                     .extractBooleanNamed(IS_FLOATING_INTEREST_RATE_CALCULATION_ALLOWED, element);
@@ -1611,8 +1592,7 @@ public final class LoanProductDataValidator {
             if (this.fromApiJsonHelper.parameterExists(INTEREST_RATE_DIFFERENTIAL, element)) {
                 interestRateDifferential = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(INTEREST_RATE_DIFFERENTIAL, element);
             }
-            baseDataValidator.reset().parameter(INTEREST_RATE_DIFFERENTIAL).value(interestRateDifferential).notNull()
-                    .zeroOrPositiveAmount();
+            baseDataValidator.reset().parameter(INTEREST_RATE_DIFFERENTIAL).value(interestRateDifferential).notNull();
 
             final String minDifferentialLendingRateParameterName = MIN_DIFFERENTIAL_LENDING_RATE;
             BigDecimal minDifferentialLendingRate = loanProduct.getFloatingRates() == null ? null
@@ -1621,8 +1601,7 @@ public final class LoanProductDataValidator {
                 minDifferentialLendingRate = this.fromApiJsonHelper
                         .extractBigDecimalWithLocaleNamed(minDifferentialLendingRateParameterName, element);
             }
-            baseDataValidator.reset().parameter(minDifferentialLendingRateParameterName).value(minDifferentialLendingRate).notNull()
-                    .zeroOrPositiveAmount();
+            baseDataValidator.reset().parameter(minDifferentialLendingRateParameterName).value(minDifferentialLendingRate).notNull();
 
             final String defaultDifferentialLendingRateParameterName = DEFAULT_DIFFERENTIAL_LENDING_RATE;
             BigDecimal defaultDifferentialLendingRate = loanProduct.getFloatingRates() == null ? null
@@ -1631,8 +1610,8 @@ public final class LoanProductDataValidator {
                 defaultDifferentialLendingRate = this.fromApiJsonHelper
                         .extractBigDecimalWithLocaleNamed(defaultDifferentialLendingRateParameterName, element);
             }
-            baseDataValidator.reset().parameter(defaultDifferentialLendingRateParameterName).value(defaultDifferentialLendingRate).notNull()
-                    .zeroOrPositiveAmount();
+            baseDataValidator.reset().parameter(defaultDifferentialLendingRateParameterName).value(defaultDifferentialLendingRate)
+                    .notNull();
 
             final String maxDifferentialLendingRateParameterName = MAX_DIFFERENTIAL_LENDING_RATE;
             BigDecimal maxDifferentialLendingRate = loanProduct.getFloatingRates() == null ? null
@@ -1641,26 +1620,9 @@ public final class LoanProductDataValidator {
                 maxDifferentialLendingRate = this.fromApiJsonHelper
                         .extractBigDecimalWithLocaleNamed(maxDifferentialLendingRateParameterName, element);
             }
-            baseDataValidator.reset().parameter(maxDifferentialLendingRateParameterName).value(maxDifferentialLendingRate).notNull()
-                    .zeroOrPositiveAmount();
-
-            if (defaultDifferentialLendingRate != null && defaultDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0
-                    && minDifferentialLendingRate != null && minDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0) {
-                baseDataValidator.reset().parameter(DEFAULT_DIFFERENTIAL_LENDING_RATE).value(defaultDifferentialLendingRate)
-                        .notLessThanMin(minDifferentialLendingRate);
-            }
-
-            if (maxDifferentialLendingRate != null && maxDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0
-                    && minDifferentialLendingRate != null && minDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0) {
-                baseDataValidator.reset().parameter(MAX_DIFFERENTIAL_LENDING_RATE).value(maxDifferentialLendingRate)
-                        .notLessThanMin(minDifferentialLendingRate);
-            }
-
-            if (maxDifferentialLendingRate != null && maxDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0
-                    && defaultDifferentialLendingRate != null && defaultDifferentialLendingRate.compareTo(BigDecimal.ZERO) >= 0) {
-                baseDataValidator.reset().parameter(MAX_DIFFERENTIAL_LENDING_RATE).value(maxDifferentialLendingRate)
-                        .notLessThanMin(defaultDifferentialLendingRate);
-            }
+            baseDataValidator.reset().parameter(maxDifferentialLendingRateParameterName).value(maxDifferentialLendingRate).notNull();
+            validateFloatingRateDifferentialBounds(baseDataValidator, interestRateDifferential, minDifferentialLendingRate,
+                    defaultDifferentialLendingRate, maxDifferentialLendingRate);
 
             Boolean isFloatingInterestRateCalculationAllowed = loanProduct.getFloatingRates() == null ? null
                     : loanProduct.getFloatingRates().isFloatingInterestRateCalculationAllowed();
@@ -2245,6 +2207,28 @@ public final class LoanProductDataValidator {
         validatePrincipalMinMaxConstraint(element, loanProduct, baseDataValidator);
         validateNumberOfRepaymentsMinMaxConstraint(element, loanProduct, baseDataValidator);
         validateNominalInterestRatePerPeriodMinMaxConstraint(element, loanProduct, baseDataValidator);
+    }
+
+    private void validateFloatingRateDifferentialBounds(final DataValidatorBuilder baseDataValidator,
+            final BigDecimal interestRateDifferential, final BigDecimal minDifferentialLendingRate,
+            final BigDecimal defaultDifferentialLendingRate, final BigDecimal maxDifferentialLendingRate) {
+        if (defaultDifferentialLendingRate != null && minDifferentialLendingRate != null) {
+            baseDataValidator.reset().parameter(DEFAULT_DIFFERENTIAL_LENDING_RATE).value(defaultDifferentialLendingRate)
+                    .notLessThanMin(minDifferentialLendingRate);
+        }
+        if (maxDifferentialLendingRate != null && minDifferentialLendingRate != null) {
+            baseDataValidator.reset().parameter(MAX_DIFFERENTIAL_LENDING_RATE).value(maxDifferentialLendingRate)
+                    .notLessThanMin(minDifferentialLendingRate);
+        }
+        if (maxDifferentialLendingRate != null && defaultDifferentialLendingRate != null) {
+            baseDataValidator.reset().parameter(MAX_DIFFERENTIAL_LENDING_RATE).value(maxDifferentialLendingRate)
+                    .notLessThanMin(defaultDifferentialLendingRate);
+        }
+        if (interestRateDifferential != null && minDifferentialLendingRate != null && maxDifferentialLendingRate != null
+                && minDifferentialLendingRate.compareTo(maxDifferentialLendingRate) <= 0) {
+            baseDataValidator.reset().parameter(INTEREST_RATE_DIFFERENTIAL).value(interestRateDifferential)
+                    .inMinAndMaxAmountRange(minDifferentialLendingRate, maxDifferentialLendingRate);
+        }
     }
 
     public void validateMinMaxConstraints(final JsonElement element, final DataValidatorBuilder baseDataValidator,

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidatorTest.java
@@ -1,0 +1,309 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.configuration.domain.GlobalConfigurationProperty;
+import org.apache.fineract.infrastructure.configuration.domain.GlobalConfigurationRepositoryWrapper;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
+import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityRelationRepository;
+import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityToEntityMappingRepository;
+import org.apache.fineract.organisation.holiday.domain.HolidayRepository;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
+import org.apache.fineract.portfolio.calendar.domain.CalendarInstanceRepository;
+import org.apache.fineract.portfolio.client.domain.Client;
+import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.portfolio.collateralmanagement.domain.ClientCollateralManagementRepositoryWrapper;
+import org.apache.fineract.portfolio.collateralmanagement.service.LoanCollateralAssembler;
+import org.apache.fineract.portfolio.group.domain.GroupRepositoryWrapper;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanLifecycleStateMachine;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleTransactionProcessorFactory;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.apache.fineract.portfolio.loanaccount.mapper.LoanMapper;
+import org.apache.fineract.portfolio.loanaccount.service.LoanReadPlatformService;
+import org.apache.fineract.portfolio.loanaccount.service.LoanUtilService;
+import org.apache.fineract.portfolio.loanproduct.domain.AdvancedPaymentAllocationsValidator;
+import org.apache.fineract.portfolio.loanproduct.domain.InterestCalculationPeriodMethod;
+import org.apache.fineract.portfolio.loanproduct.domain.InterestMethod;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductFloatingRates;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
+import org.apache.fineract.portfolio.loanproduct.serialization.LoanProductDataValidator;
+import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LoanApplicationValidatorTest {
+
+    private static final LocalDate BUSINESS_DATE = LocalDate.of(2025, 6, 1);
+    private static final String TRANSACTION_PROCESSING_STRATEGY = "mifos-standard-strategy";
+
+    @Spy
+    private FromJsonHelper fromApiJsonHelper = new FromJsonHelper();
+    @Mock
+    private LoanScheduleValidator loanScheduleValidator;
+    @Mock
+    private ClientCollateralManagementRepositoryWrapper clientCollateralManagementRepositoryWrapper;
+    @Mock
+    private LoanChargeApiJsonValidator loanChargeApiJsonValidator;
+    @Mock
+    private LoanRepaymentScheduleTransactionProcessorFactory loanRepaymentScheduleTransactionProcessorFactory;
+    @Mock
+    private AdvancedPaymentAllocationsValidator advancedPaymentAllocationsValidator;
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private LoanProductRepository loanProductRepository;
+    @Mock
+    private ClientRepositoryWrapper clientRepository;
+    @Mock
+    private GroupRepositoryWrapper groupRepository;
+    @Mock
+    private LoanReadPlatformService loanReadPlatformService;
+    @Mock
+    private LoanProductDataValidator loanProductDataValidator;
+    @Mock
+    private GlobalConfigurationRepositoryWrapper globalConfigurationRepository;
+    @Mock
+    private FineractEntityToEntityMappingRepository entityMappingRepository;
+    @Mock
+    private FineractEntityRelationRepository fineractEntityRelationRepository;
+    @Mock
+    private LoanRepositoryWrapper loanRepositoryWrapper;
+    @Mock
+    private LoanProductReadPlatformService loanProductReadPlatformService;
+    @Mock
+    private LoanCollateralAssembler collateralAssembler;
+    @Mock
+    private WorkingDaysRepositoryWrapper workingDaysRepository;
+    @Mock
+    private HolidayRepository holidayRepository;
+    @Mock
+    private SavingsAccountRepositoryWrapper savingsAccountRepository;
+    @Mock
+    private LoanLifecycleStateMachine loanLifecycleStateMachine;
+    @Mock
+    private CalendarInstanceRepository calendarInstanceRepository;
+    @Mock
+    private LoanUtilService loanUtilService;
+    @Mock
+    private EntityDatatableChecksWritePlatformService entityDatatableChecksWritePlatformService;
+    @Mock
+    private LoanMapper loanMapper;
+
+    @InjectMocks
+    private LoanApplicationValidator validator;
+
+    private LoanProduct floatingLoanProduct;
+    private LoanProduct fixedLoanProduct;
+    private LoanProductRelatedDetail productRelatedDetail;
+    private Client client;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null));
+        HashMap<BusinessDateType, LocalDate> dates = new HashMap<>();
+        dates.put(BusinessDateType.BUSINESS_DATE, BUSINESS_DATE);
+        dates.put(BusinessDateType.COB_DATE, BUSINESS_DATE.minusDays(1));
+        ThreadLocalContextUtil.setBusinessDates(dates);
+
+        productRelatedDetail = mock(LoanProductRelatedDetail.class);
+        when(productRelatedDetail.getLoanScheduleProcessingType()).thenReturn(LoanScheduleProcessingType.HORIZONTAL);
+        when(productRelatedDetail.getLoanScheduleType()).thenReturn(LoanScheduleType.CUMULATIVE);
+        when(productRelatedDetail.getInterestMethod()).thenReturn(InterestMethod.DECLINING_BALANCE);
+        when(productRelatedDetail.getInterestCalculationPeriodMethod())
+                .thenReturn(InterestCalculationPeriodMethod.SAME_AS_REPAYMENT_PERIOD);
+        when(productRelatedDetail.isAllowPartialPeriodInterestCalculation()).thenReturn(true);
+
+        floatingLoanProduct = loanProduct(true, new BigDecimal("-1.00"), new BigDecimal("1.00"));
+        fixedLoanProduct = loanProduct(false, BigDecimal.ZERO, BigDecimal.ZERO);
+        when(loanProductRepository.findById(1L)).thenReturn(Optional.of(floatingLoanProduct));
+        when(loanProductRepository.findById(2L)).thenReturn(Optional.of(fixedLoanProduct));
+
+        Office office = mock(Office.class);
+        when(office.getId()).thenReturn(1L);
+        client = mock(Client.class);
+        when(client.getId()).thenReturn(1L);
+        when(client.getOffice()).thenReturn(office);
+        when(clientRepository.findOneWithNotFoundDetection(1L)).thenReturn(client);
+
+        GlobalConfigurationProperty officeSpecificProducts = new GlobalConfigurationProperty().setEnabled(false);
+        when(globalConfigurationRepository
+                .findOneByNameWithNotFoundDetection(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED))
+                .thenReturn(officeSpecificProducts);
+        when(configurationDomainService.allowTransactionsOnNonWorkingDayEnabled()).thenReturn(true);
+        when(configurationDomainService.allowTransactionsOnHolidayEnabled()).thenReturn(true);
+        when(holidayRepository.findByOfficeIdAndGreaterThanDate(anyLong(), any(LocalDate.class), anyInt())).thenReturn(List.of());
+        when(loanRepositoryWrapper.findActiveLoansLoanProductIdsByClient(1L, LoanStatus.ACTIVE)).thenReturn(List.of());
+    }
+
+    @Test
+    void validateForCreateAcceptsNegativeInterestRateDifferentialWithinProductRange() {
+        validator.validateForCreate(command(createLoanJson(1L, "-0.25")));
+    }
+
+    @Test
+    void validateForCreateRejectsInterestRateDifferentialBelowProductMinimum() {
+        assertValidationError(() -> validator.validateForCreate(command(createLoanJson(1L, "-1.25"))), "interestRateDifferential");
+    }
+
+    @Test
+    void validateForCreateRejectsInterestRateDifferentialAboveProductMaximum() {
+        assertValidationError(() -> validator.validateForCreate(command(createLoanJson(1L, "1.25"))), "interestRateDifferential");
+    }
+
+    @Test
+    void validateForCreateRejectsInterestRateDifferentialForFixedRateProduct() {
+        assertValidationError(() -> validator.validateForCreate(command(createLoanJson(2L, "-0.25"))), "interestRateDifferential");
+    }
+
+    @Test
+    void validateForModifyAcceptsNegativeInterestRateDifferentialWithinProductRange() {
+        validator.validateForModify(command(updateLoanJson("-0.25")), loan("-0.25"));
+    }
+
+    @Test
+    void validateForModifyRejectsInterestRateDifferentialBelowProductMinimum() {
+        assertValidationError(() -> validator.validateForModify(command(updateLoanJson("-1.25")), loan("-1.25")),
+                "interestRateDifferential");
+    }
+
+    @Test
+    void validateForModifyRejectsInterestRateDifferentialAboveProductMaximum() {
+        assertValidationError(() -> validator.validateForModify(command(updateLoanJson("1.25")), loan("1.25")), "interestRateDifferential");
+    }
+
+    private LoanProduct loanProduct(boolean linkedToFloatingRate, BigDecimal minDifferential, BigDecimal maxDifferential) {
+        LoanProduct product = mock(LoanProduct.class);
+        when(product.isLinkedToFloatingInterestRate()).thenReturn(linkedToFloatingRate);
+        when(product.getLoanProductRelatedDetail()).thenReturn(productRelatedDetail);
+        when(product.getTransactionProcessingStrategyCode()).thenReturn(TRANSACTION_PROCESSING_STRATEGY);
+        if (linkedToFloatingRate) {
+            LoanProductFloatingRates floatingRates = mock(LoanProductFloatingRates.class);
+            when(floatingRates.getMinDifferentialLendingRate()).thenReturn(minDifferential);
+            when(floatingRates.getMaxDifferentialLendingRate()).thenReturn(maxDifferential);
+            when(floatingRates.isFloatingInterestRateCalculationAllowed()).thenReturn(true);
+            when(product.getFloatingRates()).thenReturn(floatingRates);
+        }
+        return product;
+    }
+
+    private Loan loan(String interestRateDifferential) {
+        Loan loan = mock(Loan.class);
+        when(loan.isSubmittedAndPendingApproval()).thenReturn(true);
+        when(loan.getLoanProduct()).thenReturn(floatingLoanProduct);
+        when(loan.loanProduct()).thenReturn(floatingLoanProduct);
+        when(loan.getClient()).thenReturn(client);
+        when(loan.getGroup()).thenReturn(null);
+        when(loan.getLoanProductRelatedDetail()).thenReturn(productRelatedDetail);
+        when(loan.getLoanRepaymentScheduleDetail()).thenReturn(productRelatedDetail);
+        when(loan.getInterestRateDifferential()).thenReturn(new BigDecimal(interestRateDifferential));
+        when(loan.getExpectedDisbursementDate()).thenReturn(BUSINESS_DATE);
+        when(loan.getSubmittedOnDate()).thenReturn(BUSINESS_DATE.minusMonths(1));
+        when(loan.getLoanTermVariations()).thenReturn(List.of());
+        return loan;
+    }
+
+    private static JsonCommand command(String json) {
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.json()).thenReturn(json);
+        when(command.longValueOfParameterNamed("productId")).thenReturn(null);
+        return command;
+    }
+
+    private static String createLoanJson(Long productId, String interestRateDifferential) {
+        return """
+                {
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "productId": %s,
+                  "clientId": 1,
+                  "loanType": "individual",
+                  "principal": 1000,
+                  "loanTermFrequency": 12,
+                  "loanTermFrequencyType": 2,
+                  "numberOfRepayments": 12,
+                  "repaymentEvery": 1,
+                  "repaymentFrequencyType": 2,
+                  "interestType": 0,
+                  "interestCalculationPeriodType": 1,
+                  "allowPartialPeriodInterestCalcualtion": true,
+                  "isFloatingInterestRate": false,
+                  "interestRateDifferential": %s,
+                  "amortizationType": 1,
+                  "expectedDisbursementDate": "01 June 2025",
+                  "submittedOnDate": "01 May 2025",
+                  "transactionProcessingStrategyCode": "mifos-standard-strategy"
+                }
+                """.formatted(productId, interestRateDifferential);
+    }
+
+    private static String updateLoanJson(String interestRateDifferential) {
+        return """
+                {
+                  "locale": "en",
+                  "dateFormat": "dd MMMM yyyy",
+                  "loanType": "individual",
+                  "interestRateDifferential": %s
+                }
+                """.formatted(interestRateDifferential);
+    }
+
+    private static void assertValidationError(Runnable action, String parameterName) {
+        assertThatThrownBy(action::run).isInstanceOf(PlatformApiDataValidationException.class)
+                .satisfies(ex -> assertThat(((PlatformApiDataValidationException) ex).getErrors())
+                        .anySatisfy(error -> assertThat(error.getParameterName()).isEqualTo(parameterName)));
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidatorTest.java
@@ -76,9 +76,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrap
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -90,8 +88,6 @@ class LoanApplicationValidatorTest {
     private static final LocalDate BUSINESS_DATE = LocalDate.of(2025, 6, 1);
     private static final String TRANSACTION_PROCESSING_STRATEGY = "mifos-standard-strategy";
 
-    @Spy
-    private FromJsonHelper fromApiJsonHelper = new FromJsonHelper();
     @Mock
     private LoanScheduleValidator loanScheduleValidator;
     @Mock
@@ -143,7 +139,6 @@ class LoanApplicationValidatorTest {
     @Mock
     private LoanMapper loanMapper;
 
-    @InjectMocks
     private LoanApplicationValidator validator;
 
     private LoanProduct floatingLoanProduct;
@@ -153,6 +148,13 @@ class LoanApplicationValidatorTest {
 
     @BeforeEach
     void setUp() {
+        validator = new LoanApplicationValidator(new FromJsonHelper(), loanScheduleValidator, clientCollateralManagementRepositoryWrapper,
+                loanChargeApiJsonValidator, loanRepaymentScheduleTransactionProcessorFactory, advancedPaymentAllocationsValidator,
+                configurationDomainService, loanProductRepository, clientRepository, groupRepository, loanReadPlatformService,
+                loanProductDataValidator, globalConfigurationRepository, entityMappingRepository, fineractEntityRelationRepository,
+                loanRepositoryWrapper, loanProductReadPlatformService, collateralAssembler, workingDaysRepository, holidayRepository,
+                savingsAccountRepository, loanLifecycleStateMachine, calendarInstanceRepository, loanUtilService,
+                entityDatatableChecksWritePlatformService, loanMapper);
         ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null));
         HashMap<BusinessDateType, LocalDate> dates = new HashMap<>();
         dates.put(BusinessDateType.BUSINESS_DATE, BUSINESS_DATE);
@@ -268,7 +270,7 @@ class LoanApplicationValidatorTest {
                 {
                   "locale": "en",
                   "dateFormat": "dd MMMM yyyy",
-                  "productId": %s,
+                  "productId": __PRODUCT_ID__,
                   "clientId": 1,
                   "loanType": "individual",
                   "principal": 1000,
@@ -281,13 +283,13 @@ class LoanApplicationValidatorTest {
                   "interestCalculationPeriodType": 1,
                   "allowPartialPeriodInterestCalcualtion": true,
                   "isFloatingInterestRate": false,
-                  "interestRateDifferential": %s,
+                  "interestRateDifferential": __INTEREST_RATE_DIFFERENTIAL__,
                   "amortizationType": 1,
                   "expectedDisbursementDate": "01 June 2025",
                   "submittedOnDate": "01 May 2025",
                   "transactionProcessingStrategyCode": "mifos-standard-strategy"
                 }
-                """.formatted(productId, interestRateDifferential);
+                """.replace("__PRODUCT_ID__", productId.toString()).replace("__INTEREST_RATE_DIFFERENTIAL__", interestRateDifferential);
     }
 
     private static String updateLoanJson(String interestRateDifferential) {
@@ -296,9 +298,9 @@ class LoanApplicationValidatorTest {
                   "locale": "en",
                   "dateFormat": "dd MMMM yyyy",
                   "loanType": "individual",
-                  "interestRateDifferential": %s
+                  "interestRateDifferential": __INTEREST_RATE_DIFFERENTIAL__
                 }
-                """.formatted(interestRateDifferential);
+                """.replace("__INTEREST_RATE_DIFFERENTIAL__", interestRateDifferential);
     }
 
     private static void assertValidationError(Runnable action, String parameterName) {

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidatorTest.java
@@ -23,13 +23,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
+import java.util.List;
 import org.apache.fineract.accounting.producttoaccountmapping.service.ProductToGLAccountMappingHelper;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.portfolio.floatingrates.domain.FloatingRate;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleTransactionProcessorFactory;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.apache.fineract.portfolio.loanproduct.domain.AdvancedPaymentAllocationsJsonParser;
 import org.apache.fineract.portfolio.loanproduct.domain.AdvancedPaymentAllocationsValidator;
+import org.apache.fineract.portfolio.loanproduct.domain.InterestCalculationPeriodMethod;
+import org.apache.fineract.portfolio.loanproduct.domain.InterestMethod;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductFloatingRates;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductInterestRecalculationDetails;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRelatedDetail;
+import org.apache.fineract.portfolio.loanproduct.domain.RecalculationFrequencyType;
+import org.apache.fineract.portfolio.loanproduct.domain.RepaymentStartDateType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -99,10 +113,76 @@ class LoanProductDataValidatorTest {
                 "interestRateDifferential");
     }
 
+    @Test
+    void validateForUpdateAcceptsExistingFloatingProductDifferentialInsideNegativeRange() {
+        validator.validateForUpdate(command(updateProductJson()), linkedFloatingProduct("-0.25", "-1.00", "0.00", "1.00"));
+    }
+
+    @Test
+    void validateForUpdateRejectsPartialMaximumNarrowedBelowExistingProductDifferential() {
+        LoanProduct loanProduct = linkedFloatingProduct("0.00", "-1.00", "-0.50", "1.00");
+
+        assertValidationError(() -> validator.validateForUpdate(command(updateMaxDifferentialJson("-0.10")), loanProduct),
+                "interestRateDifferential");
+    }
+
     private static JsonCommand command(String json) {
         JsonCommand command = mock(JsonCommand.class);
         when(command.json()).thenReturn(json);
         return command;
+    }
+
+    private static LoanProduct linkedFloatingProduct(String interestRateDifferential, String minDifferential, String defaultDifferential,
+            String maxDifferential) {
+        LoanProductRelatedDetail relatedDetail = mock(LoanProductRelatedDetail.class);
+        when(relatedDetail.getRepayEvery()).thenReturn(1);
+        when(relatedDetail.getGraceOnPrincipalPayment()).thenReturn(0);
+        when(relatedDetail.getGraceOnInterestPayment()).thenReturn(0);
+        when(relatedDetail.getGraceOnInterestCharged()).thenReturn(0);
+        when(relatedDetail.getInterestMethod()).thenReturn(InterestMethod.DECLINING_BALANCE);
+        when(relatedDetail.getInterestCalculationPeriodMethod()).thenReturn(InterestCalculationPeriodMethod.SAME_AS_REPAYMENT_PERIOD);
+        when(relatedDetail.isAllowPartialPeriodInterestCalculation()).thenReturn(true);
+        when(relatedDetail.getLoanScheduleProcessingType()).thenReturn(LoanScheduleProcessingType.HORIZONTAL);
+        when(relatedDetail.getLoanScheduleType()).thenReturn(LoanScheduleType.CUMULATIVE);
+
+        FloatingRate floatingRate = mock(FloatingRate.class);
+        when(floatingRate.getId()).thenReturn(1L);
+        LoanProductFloatingRates floatingRates = mock(LoanProductFloatingRates.class);
+        when(floatingRates.getFloatingRate()).thenReturn(floatingRate);
+        when(floatingRates.getInterestRateDifferential()).thenReturn(new BigDecimal(interestRateDifferential));
+        when(floatingRates.getMinDifferentialLendingRate()).thenReturn(new BigDecimal(minDifferential));
+        when(floatingRates.getDefaultDifferentialLendingRate()).thenReturn(new BigDecimal(defaultDifferential));
+        when(floatingRates.getMaxDifferentialLendingRate()).thenReturn(new BigDecimal(maxDifferential));
+        when(floatingRates.isFloatingInterestRateCalculationAllowed()).thenReturn(true);
+
+        LoanProductInterestRecalculationDetails recalculationDetails = mock(LoanProductInterestRecalculationDetails.class);
+        when(recalculationDetails.getInterestRecalculationCompoundingMethod()).thenReturn(0);
+        when(recalculationDetails.getRestFrequencyType()).thenReturn(RecalculationFrequencyType.SAME_AS_REPAYMENT_PERIOD);
+
+        Money principal = money("1000.00");
+        Money minPrincipal = money("100.00");
+        Money maxPrincipal = money("10000.00");
+
+        LoanProduct loanProduct = mock(LoanProduct.class);
+        when(loanProduct.getLoanProductRelatedDetail()).thenReturn(relatedDetail);
+        when(loanProduct.getPrincipalAmount()).thenReturn(principal);
+        when(loanProduct.getMinPrincipalAmount()).thenReturn(minPrincipal);
+        when(loanProduct.getMaxPrincipalAmount()).thenReturn(maxPrincipal);
+        when(loanProduct.getNumberOfRepayments()).thenReturn(12);
+        when(loanProduct.getTransactionProcessingStrategyCode()).thenReturn("mifos-standard-strategy");
+        when(loanProduct.isInterestRecalculationEnabled()).thenReturn(true);
+        when(loanProduct.getProductInterestRecalculationDetails()).thenReturn(recalculationDetails);
+        when(loanProduct.isLinkedToFloatingInterestRate()).thenReturn(true);
+        when(loanProduct.getFloatingRates()).thenReturn(floatingRates);
+        when(loanProduct.getRepaymentStartDateType()).thenReturn(RepaymentStartDateType.DISBURSEMENT_DATE);
+        when(loanProduct.getPaymentAllocationRules()).thenReturn(List.of());
+        return loanProduct;
+    }
+
+    private static Money money(String amount) {
+        Money money = mock(Money.class);
+        when(money.getAmount()).thenReturn(new BigDecimal(amount));
+        return money;
     }
 
     private static String linkedFloatingProductJson(String interestRateDifferential, String minDifferential, String defaultDifferential,
@@ -131,14 +211,33 @@ class LoanProductDataValidatorTest {
                   "recalculationRestFrequencyType": 1,
                   "isLinkedToFloatingInterestRates": true,
                   "floatingRatesId": 1,
-                  "interestRateDifferential": %s,
-                  "minDifferentialLendingRate": %s,
-                  "defaultDifferentialLendingRate": %s,
-                  "maxDifferentialLendingRate": %s,
+                  "interestRateDifferential": __INTEREST_RATE_DIFFERENTIAL__,
+                  "minDifferentialLendingRate": __MIN_DIFFERENTIAL__,
+                  "defaultDifferentialLendingRate": __DEFAULT_DIFFERENTIAL__,
+                  "maxDifferentialLendingRate": __MAX_DIFFERENTIAL__,
                   "isFloatingInterestRateCalculationAllowed": true,
                   "accountingRule": 1
                 }
-                """.formatted(interestRateDifferential, minDifferential, defaultDifferential, maxDifferential);
+                """.replace("__INTEREST_RATE_DIFFERENTIAL__", interestRateDifferential).replace("__MIN_DIFFERENTIAL__", minDifferential)
+                .replace("__DEFAULT_DIFFERENTIAL__", defaultDifferential).replace("__MAX_DIFFERENTIAL__", maxDifferential);
+    }
+
+    private static String updateProductJson() {
+        return """
+                {
+                  "locale": "en",
+                  "name": "Floating Loan Product Updated"
+                }
+                """;
+    }
+
+    private static String updateMaxDifferentialJson(String maxDifferential) {
+        return """
+                {
+                  "locale": "en",
+                  "maxDifferentialLendingRate": __MAX_DIFFERENTIAL__
+                }
+                """.replace("__MAX_DIFFERENTIAL__", maxDifferential);
     }
 
     private static String fixedProductJsonWithUnsupportedDifferential() {

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanproduct/serialization/LoanProductDataValidatorTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.fineract.accounting.producttoaccountmapping.service.ProductToGLAccountMappingHelper;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleTransactionProcessorFactory;
+import org.apache.fineract.portfolio.loanproduct.domain.AdvancedPaymentAllocationsJsonParser;
+import org.apache.fineract.portfolio.loanproduct.domain.AdvancedPaymentAllocationsValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LoanProductDataValidatorTest {
+
+    @Mock
+    private LoanRepaymentScheduleTransactionProcessorFactory loanRepaymentScheduleTransactionProcessorFactory;
+    @Mock
+    private AdvancedPaymentAllocationsJsonParser advancedPaymentAllocationsJsonParser;
+    @Mock
+    private AdvancedPaymentAllocationsValidator advancedPaymentAllocationsValidator;
+    @Mock
+    private ProductToGLAccountMappingHelper productToGLAccountMappingHelper;
+
+    private LoanProductDataValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new LoanProductDataValidator(new FromJsonHelper(), loanRepaymentScheduleTransactionProcessorFactory,
+                advancedPaymentAllocationsJsonParser, advancedPaymentAllocationsValidator, productToGLAccountMappingHelper);
+    }
+
+    @Test
+    void validateForCreateAcceptsFloatingProductDifferentialRangeStartingBelowZero() {
+        validator.validateForCreate(command(linkedFloatingProductJson("0", "-5", "0", "10")));
+    }
+
+    @Test
+    void validateForCreateAcceptsProductInterestRateDifferentialInsideNegativeRange() {
+        validator.validateForCreate(command(linkedFloatingProductJson("-3", "-5", "-2", "0")));
+    }
+
+    @Test
+    void validateForCreateRejectsDefaultDifferentialBelowMinimum() {
+        assertValidationError(() -> validator.validateForCreate(command(linkedFloatingProductJson("-1", "-1", "-2", "1"))),
+                "defaultDifferentialLendingRate");
+    }
+
+    @Test
+    void validateForCreateRejectsMaximumDifferentialBelowDefault() {
+        assertValidationError(() -> validator.validateForCreate(command(linkedFloatingProductJson("0", "-5", "10", "5"))),
+                "maxDifferentialLendingRate");
+    }
+
+    @Test
+    void validateForCreateRejectsMaximumDifferentialBelowMinimum() {
+        assertValidationError(() -> validator.validateForCreate(command(linkedFloatingProductJson("5", "5", "6", "4"))),
+                "maxDifferentialLendingRate");
+    }
+
+    @Test
+    void validateForCreateRejectsProductInterestRateDifferentialOutsideRange() {
+        assertValidationError(() -> validator.validateForCreate(command(linkedFloatingProductJson("-6", "-5", "0", "10"))),
+                "interestRateDifferential");
+    }
+
+    @Test
+    void validateForCreateRejectsFloatingDifferentialForNonLinkedProduct() {
+        assertValidationError(() -> validator.validateForCreate(command(fixedProductJsonWithUnsupportedDifferential())),
+                "interestRateDifferential");
+    }
+
+    private static JsonCommand command(String json) {
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.json()).thenReturn(json);
+        return command;
+    }
+
+    private static String linkedFloatingProductJson(String interestRateDifferential, String minDifferential, String defaultDifferential,
+            String maxDifferential) {
+        return """
+                {
+                  "locale": "en",
+                  "name": "Floating Loan Product",
+                  "shortName": "FLP",
+                  "currencyCode": "USD",
+                  "digitsAfterDecimal": 2,
+                  "principal": 1000,
+                  "numberOfRepayments": 12,
+                  "repaymentEvery": 1,
+                  "repaymentFrequencyType": 2,
+                  "amortizationType": 1,
+                  "interestType": 0,
+                  "interestCalculationPeriodType": 1,
+                  "allowPartialPeriodInterestCalcualtion": true,
+                  "transactionProcessingStrategyCode": "mifos-standard-strategy",
+                  "daysInMonthType": 1,
+                  "daysInYearType": 365,
+                  "isInterestRecalculationEnabled": true,
+                  "interestRecalculationCompoundingMethod": 0,
+                  "rescheduleStrategyMethod": 1,
+                  "recalculationRestFrequencyType": 1,
+                  "isLinkedToFloatingInterestRates": true,
+                  "floatingRatesId": 1,
+                  "interestRateDifferential": %s,
+                  "minDifferentialLendingRate": %s,
+                  "defaultDifferentialLendingRate": %s,
+                  "maxDifferentialLendingRate": %s,
+                  "isFloatingInterestRateCalculationAllowed": true,
+                  "accountingRule": 1
+                }
+                """.formatted(interestRateDifferential, minDifferential, defaultDifferential, maxDifferential);
+    }
+
+    private static String fixedProductJsonWithUnsupportedDifferential() {
+        return """
+                {
+                  "locale": "en",
+                  "name": "Fixed Loan Product",
+                  "shortName": "FIX",
+                  "currencyCode": "USD",
+                  "digitsAfterDecimal": 2,
+                  "principal": 1000,
+                  "numberOfRepayments": 12,
+                  "repaymentEvery": 1,
+                  "repaymentFrequencyType": 2,
+                  "amortizationType": 1,
+                  "interestType": 0,
+                  "interestCalculationPeriodType": 1,
+                  "transactionProcessingStrategyCode": "mifos-standard-strategy",
+                  "daysInMonthType": 1,
+                  "daysInYearType": 365,
+                  "isInterestRecalculationEnabled": false,
+                  "isLinkedToFloatingInterestRates": false,
+                  "interestRatePerPeriod": 10,
+                  "interestRateFrequencyType": 2,
+                  "interestRateDifferential": -0.25,
+                  "accountingRule": 1
+                }
+                """;
+    }
+
+    private static void assertValidationError(Runnable action, String parameterName) {
+        assertThatThrownBy(action::run).isInstanceOf(PlatformApiDataValidationException.class)
+                .satisfies(ex -> assertThat(((PlatformApiDataValidationException) ex).getErrors())
+                        .anySatisfy(error -> assertThat(error.getParameterName()).isEqualTo(parameterName)));
+    }
+}


### PR DESCRIPTION
## Summary
- Allow negative loan-level floating-rate differentials while preserving required and product min/max validation.
- Allow linked floating products to configure negative product differential ranges and validate min/default/max ordering without non-negative assumptions.
- Add focused provider validator tests and MNZL schedule tests proving negative spreads and forced floating DTO behavior keep future floating-rate periods applicable.

## Behavior
Effective floating rates remain additive:

`floating/base period rate + product differential + loan differential`

No API field names changed and no migration is included. MNZL products must configure `minDifferentialLendingRate` below zero, for example `-5.00`, for a loan-level discount such as `-0.25` to pass validation.

## Data Audit
Read-only staging data audit checked 3 linked floating-rate product configurations; none violate product differential range or min/default/max ordering validation.

## Verification
- `./gradlew :fineract-provider:test --tests '*LoanApplicationValidatorTest' --tests '*LoanProductDataValidatorTest' :custom:mnzl:loan:schedule-api:test --tests '*MnzlLoanUtilServiceTest' --tests '*MnzlLoanTermVariationsEnricherTest'`
- `./gradlew :fineract-provider:spotbugsTest`
- `./gradlew :fineract-provider:spotlessCheck :custom:mnzl:loan:schedule-api:spotlessCheck`
