### PR TITLE
Apply working-day grace to the overdue-penalty scheduled job

### DIFF
--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlGraceConfiguration.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlGraceConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepository
 import org.apache.fineract.portfolio.delinquency.helper.DelinquencyEffectivePauseHelper;
 import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainService;
 import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainServiceImpl;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanTransactionReadService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -70,5 +71,16 @@ public class MnzlGraceConfiguration {
             LoanChargeWritePlatformService loanChargeWritePlatformService, MnzlWorkingDayCalculator workingDayCalculator) {
         return new MnzlApplyChargeToOverdueLoansBusinessStep(configurationDomainService, loanChargeWritePlatformService,
                 workingDayCalculator);
+    }
+
+    /**
+     * Enforces working-day grace at the shared write chokepoint so the standalone "Apply penalty to overdue loans"
+     * scheduled job (which bypasses the COB step) also honours working days. Spring's AspectJ auto-proxy picks up the
+     * {@code @Aspect} on this {@code @Bean}-registered class.
+     */
+    @Bean
+    public MnzlOverdueChargeGraceAspect mnzlOverdueChargeGraceAspect(MnzlWorkingDayCalculator workingDayCalculator,
+            ConfigurationDomainService configurationDomainService, LoanRepositoryWrapper loanRepositoryWrapper) {
+        return new MnzlOverdueChargeGraceAspect(workingDayCalculator, configurationDomainService, loanRepositoryWrapper);
     }
 }

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspect.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspect.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.organisation.holiday.domain.Holiday;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.OverdueLoanScheduleData;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+/**
+ * Enforces working-day grace on overdue-penalty application at the single shared chokepoint
+ * {@code LoanChargeWritePlatformService.applyOverdueChargesForLoan(loanId, overdueData)}.
+ *
+ * <p>
+ * Both overdue-penalty entry points funnel through that method:
+ * <ul>
+ * <li>the COB step {@code APPLY_CHARGE_TO_OVERDUE_LOANS}, and</li>
+ * <li>the standalone scheduled job {@code APPLY_CHARGE_TO_OVERDUE_LOAN_INSTALLMENT} ("Apply penalty to overdue loans"),
+ * whose {@code retrieveAllLoansWithOverdueInstallments} query selects installments using calendar-day
+ * {@code penaltyWaitPeriod}.</li>
+ * </ul>
+ * The incoming collection has already passed the upstream calendar-day filter; this advice drops any installment whose
+ * <em>working-day</em> grace (skipping weekends per {@code m_working_days} and active {@code m_holiday} entries for the
+ * loan's office) has not yet elapsed as of the current business/COB date, then proceeds with the survivors.
+ *
+ * <p>
+ * Note: this advice can only narrow the collection it is given. With {@code backdate-penalties-enabled = false} the
+ * scheduled job's query surfaces an installment only on its exact calendar-grace day, which is earlier than the
+ * working-day grace day, so for that specific configuration the standalone job still cannot reach the later working-day
+ * date. The COB-step path handles backdate-disabled correctly via {@link MnzlApplyChargeToOverdueLoansBusinessStep}.
+ */
+@Aspect
+@Slf4j
+@RequiredArgsConstructor
+public class MnzlOverdueChargeGraceAspect {
+
+    private final MnzlWorkingDayCalculator workingDayCalculator;
+    private final ConfigurationDomainService configurationDomainService;
+    private final LoanRepositoryWrapper loanRepositoryWrapper;
+
+    @Around("execution(* org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService.applyOverdueChargesForLoan(..))")
+    public Object enforceWorkingDayGrace(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        if (args.length < 2 || !(args[0] instanceof Long loanId) || !(args[1] instanceof Collection<?> rawData) || rawData.isEmpty()) {
+            return joinPoint.proceed();
+        }
+        @SuppressWarnings("unchecked")
+        Collection<OverdueLoanScheduleData> overdueData = (Collection<OverdueLoanScheduleData>) rawData;
+
+        final int penaltyWaitPeriod = penaltyWaitPeriodDays();
+        final LocalDate currentDate = DateUtils.getBusinessLocalDate();
+        final Loan loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loanId);
+        final Long officeId = loan.getOffice() != null ? loan.getOffice().getId() : null;
+
+        // Hoist working-days config + holiday list once; anchor the holiday lookup at the earliest candidate due date.
+        final WorkingDays workingDays = workingDayCalculator.getWorkingDays();
+        LocalDate earliestDueDate = null;
+        for (OverdueLoanScheduleData data : overdueData) {
+            LocalDate due = installmentDueDate(loan, data.getPeriodNumber());
+            if (due != null && (earliestDueDate == null || due.isBefore(earliestDueDate))) {
+                earliestDueDate = due;
+            }
+        }
+        final List<Holiday> holidays = workingDayCalculator.getActiveHolidaysForOffice(officeId,
+                earliestDueDate != null ? earliestDueDate : currentDate);
+
+        List<OverdueLoanScheduleData> stillInGrace = new ArrayList<>();
+        List<OverdueLoanScheduleData> due = new ArrayList<>();
+        for (OverdueLoanScheduleData data : overdueData) {
+            LocalDate installmentDueDate = installmentDueDate(loan, data.getPeriodNumber());
+            if (installmentDueDate == null) {
+                // Cannot resolve the installment; leave the upstream decision untouched rather than suppress a charge.
+                due.add(data);
+                continue;
+            }
+            LocalDate firstPenaltyDate = workingDayCalculator.addWorkingDays(installmentDueDate, penaltyWaitPeriod, workingDays, holidays);
+            if (currentDate.isBefore(firstPenaltyDate)) {
+                stillInGrace.add(data);
+            } else {
+                due.add(data);
+            }
+        }
+
+        if (!stillInGrace.isEmpty()) {
+            log.info(
+                    "Working-day grace withheld overdue penalty on loan id [{}] for {} installment(s) still within grace as of [{}] "
+                            + "(penaltyWaitPeriod={} working days); {} installment(s) proceed",
+                    loanId, stillInGrace.size(), currentDate, penaltyWaitPeriod, due.size());
+        }
+        if (due.isEmpty()) {
+            return null; // applyOverdueChargesForLoan is void; nothing is due yet
+        }
+        args[1] = due;
+        return joinPoint.proceed(args);
+    }
+
+    private int penaltyWaitPeriodDays() {
+        Long value = configurationDomainService.retrievePenaltyWaitPeriod();
+        return value == null ? 0 : Math.toIntExact(value);
+    }
+
+    private static LocalDate installmentDueDate(Loan loan, Integer periodNumber) {
+        if (periodNumber == null) {
+            return null;
+        }
+        return loan.getRepaymentScheduleInstallments().stream().filter(i -> periodNumber.equals(i.getInstallmentNumber())).findFirst()
+                .map(LoanRepaymentScheduleInstallment::getDueDate).orElse(null);
+    }
+}

--- a/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspect.java
+++ b/custom/mnzl/loan/grace/src/main/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspect.java
@@ -68,10 +68,10 @@ public class MnzlOverdueChargeGraceAspect {
     private final LoanRepositoryWrapper loanRepositoryWrapper;
 
     @Around("execution(* org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService.applyOverdueChargesForLoan(..))")
-    public Object enforceWorkingDayGrace(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object enforceWorkingDayGrace(ProceedingJoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         if (args.length < 2 || !(args[0] instanceof Long loanId) || !(args[1] instanceof Collection<?> rawData) || rawData.isEmpty()) {
-            return joinPoint.proceed();
+            return proceed(joinPoint, args);
         }
         @SuppressWarnings("unchecked")
         Collection<OverdueLoanScheduleData> overdueData = (Collection<OverdueLoanScheduleData>) rawData;
@@ -120,7 +120,18 @@ public class MnzlOverdueChargeGraceAspect {
             return null; // applyOverdueChargesForLoan is void; nothing is due yet
         }
         args[1] = due;
-        return joinPoint.proceed(args);
+        return proceed(joinPoint, args);
+    }
+
+    // Wraps joinPoint.proceed(...) so the advice need not declare `throws Throwable` (checkstyle IllegalThrows).
+    private static Object proceed(ProceedingJoinPoint joinPoint, Object[] args) {
+        try {
+            return joinPoint.proceed(args);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new RuntimeException("Error applying working-day grace to overdue charges", e);
+        }
     }
 
     private int penaltyWaitPeriodDays() {

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspectTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspectTest.java
@@ -76,6 +76,8 @@ class MnzlOverdueChargeGraceAspectTest {
     @Mock
     private LoanRepaymentScheduleInstallment installment1;
     @Mock
+    private LoanRepaymentScheduleInstallment installment2;
+    @Mock
     private ProceedingJoinPoint joinPoint;
 
     private MnzlOverdueChargeGraceAspect aspect;
@@ -126,6 +128,31 @@ class MnzlOverdueChargeGraceAspectTest {
         @SuppressWarnings("unchecked")
         List<OverdueLoanScheduleData> passed = (List<OverdueLoanScheduleData>) captor.getValue()[1];
         assertThat(passed).hasSize(1);
+    }
+
+    @Test
+    void mixedSplit_onlyInstallmentsPastGraceProceed() throws Throwable {
+        // installment 1 (due 21 Jun) has cleared its 5-working-day grace by 01 Jul; installment 2 (due 21 Jul) has not.
+        // Only installment 1 should be passed through to applyOverdueChargesForLoan.
+        LocalDate due2 = LocalDate.of(2026, 7, 21);
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(installment1, installment2));
+        when(installment2.getInstallmentNumber()).thenReturn(2);
+        when(installment2.getDueDate()).thenReturn(due2);
+        when(calculator.addWorkingDays(eq(due2), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2026, 7, 28));
+        setBusinessDate(LocalDate.of(2026, 7, 1)); // installment 1 due (firstPenaltyDate 01 Jul), installment 2 still
+                                                   // in grace
+        Object[] args = { LOAN_ID, List.of(overdue(1), overdue(2)) };
+        when(joinPoint.getArgs()).thenReturn(args);
+        when(joinPoint.proceed(any(Object[].class))).thenReturn(null);
+
+        aspect.enforceWorkingDayGrace(joinPoint);
+
+        ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
+        verify(joinPoint).proceed(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<OverdueLoanScheduleData> passed = (List<OverdueLoanScheduleData>) captor.getValue()[1];
+        assertThat(passed).hasSize(1);
+        assertThat(passed.get(0).getPeriodNumber()).isEqualTo(1);
     }
 
     @Test

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspectTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspectTest.java
@@ -102,7 +102,7 @@ class MnzlOverdueChargeGraceAspectTest {
     }
 
     @Test
-    void withholdsPenaltyWhileStillWithinWorkingDayGrace() throws Throwable {
+    void withholdsPenaltyWhileStillWithinWorkingDayGrace() {
         setBusinessDate(LocalDate.of(2026, 6, 28)); // before 01 July
         Object[] args = { LOAN_ID, List.of(overdue(1)) };
         when(joinPoint.getArgs()).thenReturn(args);
@@ -110,28 +110,23 @@ class MnzlOverdueChargeGraceAspectTest {
         Object result = aspect.enforceWorkingDayGrace(joinPoint);
 
         assertThat(result).isNull();
-        verify(joinPoint, never()).proceed(any(Object[].class));
-        verify(joinPoint, never()).proceed();
+        verifyNeverProceeded();
     }
 
     @Test
-    void appliesPenaltyOnceWorkingDayGraceHasElapsed() throws Throwable {
+    void appliesPenaltyOnceWorkingDayGraceHasElapsed() {
         setBusinessDate(LocalDate.of(2026, 7, 1)); // the 5th working day
         Object[] args = { LOAN_ID, List.of(overdue(1)) };
         when(joinPoint.getArgs()).thenReturn(args);
-        when(joinPoint.proceed(any(Object[].class))).thenReturn(null);
+        stubProceedReturnsNull();
 
         aspect.enforceWorkingDayGrace(joinPoint);
 
-        ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
-        verify(joinPoint).proceed(captor.capture());
-        @SuppressWarnings("unchecked")
-        List<OverdueLoanScheduleData> passed = (List<OverdueLoanScheduleData>) captor.getValue()[1];
-        assertThat(passed).hasSize(1);
+        assertThat(capturedProceedInstallments()).hasSize(1);
     }
 
     @Test
-    void mixedSplit_onlyInstallmentsPastGraceProceed() throws Throwable {
+    void mixedSplit_onlyInstallmentsPastGraceProceed() {
         // installment 1 (due 21 Jun) has cleared its 5-working-day grace by 01 Jul; installment 2 (due 21 Jul) has not.
         // Only installment 1 should be passed through to applyOverdueChargesForLoan.
         LocalDate due2 = LocalDate.of(2026, 7, 21);
@@ -143,27 +138,54 @@ class MnzlOverdueChargeGraceAspectTest {
                                                    // in grace
         Object[] args = { LOAN_ID, List.of(overdue(1), overdue(2)) };
         when(joinPoint.getArgs()).thenReturn(args);
-        when(joinPoint.proceed(any(Object[].class))).thenReturn(null);
+        stubProceedReturnsNull();
 
         aspect.enforceWorkingDayGrace(joinPoint);
 
-        ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
-        verify(joinPoint).proceed(captor.capture());
-        @SuppressWarnings("unchecked")
-        List<OverdueLoanScheduleData> passed = (List<OverdueLoanScheduleData>) captor.getValue()[1];
+        List<OverdueLoanScheduleData> passed = capturedProceedInstallments();
         assertThat(passed).hasSize(1);
         assertThat(passed.get(0).getPeriodNumber()).isEqualTo(1);
     }
 
     @Test
-    void emptyCollectionProceedsUntouched() throws Throwable {
+    void emptyCollectionProceedsUntouched() {
         Object[] args = { LOAN_ID, List.of() };
         when(joinPoint.getArgs()).thenReturn(args);
+        stubProceedReturnsNull();
 
         aspect.enforceWorkingDayGrace(joinPoint);
 
-        verify(joinPoint).proceed();
+        assertThat(capturedProceedInstallments()).isEmpty(); // proceeded with the original (empty) collection
         verify(calculator, never()).addWorkingDays(any(), anyInt(), any(), any());
+    }
+
+    // ---- proceed(...) stub/verify helpers: wrapped so test methods need not declare `throws Throwable`. ----
+
+    private void stubProceedReturnsNull() {
+        try {
+            when(joinPoint.proceed(any(Object[].class))).thenReturn(null);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<OverdueLoanScheduleData> capturedProceedInstallments() {
+        ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
+        try {
+            verify(joinPoint).proceed(captor.capture());
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+        return (List<OverdueLoanScheduleData>) captor.getValue()[1];
+    }
+
+    private void verifyNeverProceeded() {
+        try {
+            verify(joinPoint, never()).proceed(any(Object[].class));
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
     }
 
     private static OverdueLoanScheduleData overdue(int periodNumber) {

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspectTest.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/MnzlOverdueChargeGraceAspectTest.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.mnzl.fineract.custom.loan.grace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.organisation.workingdays.domain.RepaymentRescheduleType;
+import org.apache.fineract.organisation.workingdays.domain.WorkingDays;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.data.OverdueLoanScheduleData;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MnzlOverdueChargeGraceAspectTest {
+
+    private static final long LOAN_ID = 39550L;
+    private static final long OFFICE_ID = 1L;
+    private static final LocalDate DUE_DATE = LocalDate.of(2026, 6, 21);
+    private static final WorkingDays WORKING_DAYS = new WorkingDays("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU,MO,TU,WE,TH",
+            RepaymentRescheduleType.MOVE_TO_NEXT_WORKING_DAY.getValue(), false, false);
+
+    @Mock
+    private MnzlWorkingDayCalculator calculator;
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private LoanRepositoryWrapper loanRepositoryWrapper;
+    @Mock
+    private Loan loan;
+    @Mock
+    private Office office;
+    @Mock
+    private LoanRepaymentScheduleInstallment installment1;
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    private MnzlOverdueChargeGraceAspect aspect;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default Tenant", "UTC", null));
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
+        aspect = new MnzlOverdueChargeGraceAspect(calculator, configurationDomainService, loanRepositoryWrapper);
+
+        when(configurationDomainService.retrievePenaltyWaitPeriod()).thenReturn(5L);
+        when(loanRepositoryWrapper.findOneWithNotFoundDetection(LOAN_ID)).thenReturn(loan);
+        when(loan.getOffice()).thenReturn(office);
+        when(office.getId()).thenReturn(OFFICE_ID);
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(installment1));
+        when(installment1.getInstallmentNumber()).thenReturn(1);
+        when(installment1.getDueDate()).thenReturn(DUE_DATE);
+        when(calculator.getWorkingDays()).thenReturn(WORKING_DAYS);
+        when(calculator.getActiveHolidaysForOffice(eq(OFFICE_ID), any())).thenReturn(List.of());
+        // 5 working days from 21 June (with weekends + 24-28 holiday) -> 01 July.
+        when(calculator.addWorkingDays(eq(DUE_DATE), eq(5), eq(WORKING_DAYS), any())).thenReturn(LocalDate.of(2026, 7, 1));
+    }
+
+    @Test
+    void withholdsPenaltyWhileStillWithinWorkingDayGrace() throws Throwable {
+        setBusinessDate(LocalDate.of(2026, 6, 28)); // before 01 July
+        Object[] args = { LOAN_ID, List.of(overdue(1)) };
+        when(joinPoint.getArgs()).thenReturn(args);
+
+        Object result = aspect.enforceWorkingDayGrace(joinPoint);
+
+        assertThat(result).isNull();
+        verify(joinPoint, never()).proceed(any(Object[].class));
+        verify(joinPoint, never()).proceed();
+    }
+
+    @Test
+    void appliesPenaltyOnceWorkingDayGraceHasElapsed() throws Throwable {
+        setBusinessDate(LocalDate.of(2026, 7, 1)); // the 5th working day
+        Object[] args = { LOAN_ID, List.of(overdue(1)) };
+        when(joinPoint.getArgs()).thenReturn(args);
+        when(joinPoint.proceed(any(Object[].class))).thenReturn(null);
+
+        aspect.enforceWorkingDayGrace(joinPoint);
+
+        ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
+        verify(joinPoint).proceed(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<OverdueLoanScheduleData> passed = (List<OverdueLoanScheduleData>) captor.getValue()[1];
+        assertThat(passed).hasSize(1);
+    }
+
+    @Test
+    void emptyCollectionProceedsUntouched() throws Throwable {
+        Object[] args = { LOAN_ID, List.of() };
+        when(joinPoint.getArgs()).thenReturn(args);
+
+        aspect.enforceWorkingDayGrace(joinPoint);
+
+        verify(joinPoint).proceed();
+        verify(calculator, never()).addWorkingDays(any(), anyInt(), any(), any());
+    }
+
+    private static OverdueLoanScheduleData overdue(int periodNumber) {
+        return new OverdueLoanScheduleData(LOAN_ID, 14L, DateUtils.DEFAULT_DATE_FORMATTER.format(DUE_DATE), BigDecimal.valueOf(50),
+                DateUtils.DEFAULT_DATE_FORMAT, "en", BigDecimal.valueOf(1000), BigDecimal.valueOf(100), periodNumber);
+    }
+
+    private static void setBusinessDate(LocalDate date) {
+        HashMap<BusinessDateType, LocalDate> dates = new HashMap<>();
+        dates.put(BusinessDateType.BUSINESS_DATE, date);
+        dates.put(BusinessDateType.COB_DATE, date.minusDays(1));
+        ThreadLocalContextUtil.setBusinessDates(dates);
+    }
+}

--- a/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/integration/MnzlGraceConfigurationSpringIT.java
+++ b/custom/mnzl/loan/grace/src/test/java/co/mnzl/fineract/custom/loan/grace/integration/MnzlGraceConfigurationSpringIT.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import co.mnzl.fineract.custom.loan.grace.MnzlGraceConfiguration;
+import co.mnzl.fineract.custom.loan.grace.MnzlOverdueChargeGraceAspect;
 import co.mnzl.fineract.custom.loan.grace.MnzlWorkingDayCalculator;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -32,6 +33,7 @@ import org.apache.fineract.organisation.holiday.domain.HolidayRepositoryWrapper;
 import org.apache.fineract.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
 import org.apache.fineract.portfolio.delinquency.helper.DelinquencyEffectivePauseHelper;
 import org.apache.fineract.portfolio.delinquency.service.LoanDelinquencyDomainService;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanTransactionReadService;
 import org.junit.jupiter.api.Test;
@@ -61,6 +63,7 @@ class MnzlGraceConfigurationSpringIT {
             .withBean(ConfigurationDomainService.class, () -> mock(ConfigurationDomainService.class))
             .withBean(BusinessEventNotifierService.class, () -> mock(BusinessEventNotifierService.class))
             .withBean(LoanChargeWritePlatformService.class, () -> mock(LoanChargeWritePlatformService.class))
+            .withBean(LoanRepositoryWrapper.class, () -> mock(LoanRepositoryWrapper.class))
             // The mock subclass of LoanTransactionReadService inherits its @PersistenceContext field, so
             // Spring's PersistenceAnnotationBeanPostProcessor still tries to find an EntityManagerFactory on
             // the slice. Provide a mock so post-processing succeeds.
@@ -76,6 +79,7 @@ class MnzlGraceConfigurationSpringIT {
             assertThat(ctx).hasSingleBean(MnzlGraceConfiguration.class);
             assertThat(ctx).hasSingleBean(MnzlWorkingDayCalculator.class);
             assertThat(ctx).hasSingleBean(LoanDelinquencyDomainService.class);
+            assertThat(ctx).hasSingleBean(MnzlOverdueChargeGraceAspect.class);
             // Two LoanCOBBusinessStep @Primary beans are exposed by the config.
             assertThat(ctx).getBeans(LoanCOBBusinessStep.class).hasSize(2);
         });
@@ -97,6 +101,7 @@ class MnzlGraceConfigurationSpringIT {
             assertThat(ctx).doesNotHaveBean(MnzlWorkingDayCalculator.class);
             assertThat(ctx).doesNotHaveBean(LoanDelinquencyDomainService.class);
             assertThat(ctx).doesNotHaveBean(LoanCOBBusinessStep.class);
+            assertThat(ctx).doesNotHaveBean(MnzlOverdueChargeGraceAspect.class);
         });
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
@@ -45,6 +45,7 @@ import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -60,6 +61,28 @@ import org.junit.jupiter.api.Test;
 public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     private static final String MNZL_STRATEGY_URL = "/fineract-provider/api/v1/mnzl/loan-products/%d/strategies?" + Utils.TENANT_IDENTIFIER;
+
+    // Default working week (all 7 days = nothing reschedules) so the working-day-grace tests can restore it.
+    private static final String DEFAULT_WORKING_DAYS_RECURRENCE = "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU";
+
+    // Holidays created by the working-day-grace tests, deleted in @AfterEach so they don't leak into other tests.
+    private final List<Integer> createdHolidayIds = new ArrayList<>();
+
+    /**
+     * The working-day-grace tests mutate global state shared across the whole integration-test database — the working
+     * week, penalty-wait-period, backdate/business-date flags, and an office holiday. Restore all of it after every
+     * test so later tests (schedule and penalty assertions) are not affected.
+     */
+    @AfterEach
+    void restoreGlobalConfigAndHolidays() {
+        setWorkingDays(DEFAULT_WORKING_DAYS_RECURRENCE, 1);
+        globalConfigurationHelper.resetAllDefaultGlobalConfigurations();
+        for (Integer holidayId : createdHolidayIds) {
+            Utils.performServerDelete(requestSpec, responseSpec,
+                    "/fineract-provider/api/v1/holidays/" + holidayId + "?" + Utils.TENANT_IDENTIFIER, "{}", "resourceId");
+        }
+        createdHolidayIds.clear();
+    }
 
     /**
      * Test 1: Standard declining balance loan with 30/360 — full happy path.
@@ -406,6 +429,7 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
                 "/fineract-provider/api/v1/holidays?" + Utils.TENANT_IDENTIFIER, new Gson().toJson(body), "resourceId");
         Utils.performServerPost(requestSpec, responseSpec,
                 "/fineract-provider/api/v1/holidays/" + holidayId + "?command=activate&" + Utils.TENANT_IDENTIFIER, "{}", "resourceId");
+        createdHolidayIds.add(holidayId);
     }
 
     private PostLoanProductsResponse createMnzlDecliningBalanceProduct() {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/mnzl/MnzlDecliningBalanceLoanIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.gson.Gson;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,8 @@ import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
+import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
@@ -202,6 +205,128 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
     }
 
     /**
+     * Test 2b: Working-day grace on the overdue-penalty COB job — reproduces Mnzl staging loan 39550.
+     *
+     * Mirrors staging exactly: Egyptian working week (Sun–Thu) with MOVE_TO_NEXT_WORKING_DAY rescheduling,
+     * {@code penalty-wait-period = 5}, an active office-1 holiday 24–28 June 2026, and a loan whose first installment
+     * falls due Sunday 21 June 2026 (disbursed 21 May 2026, monthly). 21 June is a Sunday — a working day in the
+     * Sun–Thu week — so it is not rescheduled.
+     *
+     * <p>
+     * Counting 5 <em>working</em> days from 21 June, skipping Fri/Sat weekends AND the 24–28 June holiday, the 5th
+     * working day is 01 July 2026:
+     *
+     * <pre>
+     *   Jun 22 Mon  working day 1
+     *   Jun 23 Tue  working day 2
+     *   Jun 24 Wed  HOLIDAY
+     *   Jun 25 Thu  HOLIDAY
+     *   Jun 26 Fri  weekend
+     *   Jun 27 Sat  weekend
+     *   Jun 28 Sun  HOLIDAY
+     *   Jun 29 Mon  working day 3
+     *   Jun 30 Tue  working day 4
+     *   Jul 01 Wed  working day 5  ← penalty first applies here
+     * </pre>
+     *
+     * So the 5th working day is 01 July. The overdue-penalty COB step evaluates the loan as of the COB date (= business
+     * date - 1), so the penalty must be ABSENT while the COB date is 28 June (business date 29 June — where a
+     * holiday-blind calculation would already charge) and PRESENT once the COB date reaches 01 July (business date 02
+     * July).
+     */
+    @Test
+    public void testOverduePenaltyGraceCountsWorkingDaysSkippingWeekendsAndHolidays() {
+        runAt("21 May 2026", () -> {
+            // Egyptian working week with MOVE_TO_NEXT_WORKING_DAY rescheduling (matches staging m_working_days).
+            setWorkingDays("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU,MO,TU,WE,TH", 2);
+            // Staging penalty wait period.
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                    new PutGlobalConfigurationsRequest().value(5L));
+            // Active office-1 holiday spanning the same dates as the staging "testing" holiday.
+            createAndActivateHoliday("24 June 2026", "28 June 2026");
+
+            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Integer penaltyChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
+                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
+            PostLoanProductsResponse product = loanProductHelper.createLoanProduct(
+                    buildDecliningBalanceProduct(30, 360).charges(List.of(new LoanProductChargeData().id(penaltyChargeId.longValue()))));
+            setMnzlProductStrategy(product.getResourceId());
+
+            // Disburse 21 May 2026 -> installment 1 due Sunday 21 June 2026 (matches staging loan 39550).
+            Long loanId = applyApproveDisburseLoan(clientId, product.getResourceId(), 120000.0, 12.0, 12, "21 May 2026");
+            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoanDetails(loanId);
+            assertEquals(LocalDate.of(2026, 6, 21), firstInstallmentDueDate(loan), "First installment should be due Sunday 21 June 2026");
+
+            // The overdue-penalty COB step reads the COB date (= business date - 1), so a business date of D evaluates
+            // the loan as of COB date D-1.
+
+            // (1) Business date 29 June -> COB date 28 June. A holiday-blind calc lands the 5th working day on 28 June
+            // and WOULD charge here; the working-day-aware grace (24-28 June holiday + Fri/Sat) pushes it to 01 July,
+            // so
+            // there must still be NO penalty. This is the regression guard against the staging behaviour.
+            updateBusinessDate("29 June 2026");
+            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            loan = loanTransactionHelper.getLoanDetails(loanId);
+            assertEquals(0.0, Utils.getDoubleValue(loan.getSummary().getPenaltyChargesOutstanding()), 0.0001,
+                    "No penalty while COB date is 28 June: holiday 24-28 + weekend push the 5th working day to 01 July");
+
+            // (2) Business date 02 July -> COB date 01 July = the 5th working day after the 21 June due date. Applies.
+            updateBusinessDate("02 July 2026");
+            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            loan = loanTransactionHelper.getLoanDetails(loanId);
+            assertTrue(Utils.getDoubleValue(loan.getSummary().getPenaltyChargesOutstanding()) > 0,
+                    "Overdue penalty should be applied once the COB date reaches 01 July (5th working day after 21 June)");
+        });
+    }
+
+    /**
+     * Test 2c: Working-day grace via the standalone "Apply penalty to overdue loans" scheduled job — the exact job run
+     * on Mnzl staging (not COB). Same staging config as the COB test above. Unlike the COB step, this job evaluates the
+     * loan as of the business date directly (no COB-date lag), so the penalty must be ABSENT at business date 30 June
+     * (where the calendar-day query already surfaces the installment and a holiday-blind run would charge) and PRESENT
+     * at business date 01 July (the 5th working day). {@code backdate-penalties-enabled = true} so the job's query
+     * keeps surfacing the installment up to the working-day date.
+     */
+    @Test
+    public void testScheduledJobOverduePenaltyHonoursWorkingDayGrace() {
+        runAt("21 May 2026", () -> {
+            setWorkingDays("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU,MO,TU,WE,TH", 2);
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                    new PutGlobalConfigurationsRequest().value(5L));
+            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.BACKDATE_PENALTIES_ENABLED,
+                    new PutGlobalConfigurationsRequest().enabled(true));
+            createAndActivateHoliday("24 June 2026", "28 June 2026");
+
+            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Integer penaltyChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
+                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
+            PostLoanProductsResponse product = loanProductHelper.createLoanProduct(
+                    buildDecliningBalanceProduct(30, 360).charges(List.of(new LoanProductChargeData().id(penaltyChargeId.longValue()))));
+            setMnzlProductStrategy(product.getResourceId());
+
+            Long loanId = applyApproveDisburseLoan(clientId, product.getResourceId(), 120000.0, 12.0, 12, "21 May 2026");
+            assertEquals(LocalDate.of(2026, 6, 21), firstInstallmentDueDate(loanTransactionHelper.getLoanDetails(loanId)),
+                    "First installment should be due Sunday 21 June 2026");
+
+            // (1) Business date 30 June: calendar grace (since 26 June) has elapsed and the job's query surfaces the
+            // installment, but the working-day grace runs to 01 July -> the aspect must withhold. NO penalty. This is
+            // the regression guard for the standalone-job path against the staging behaviour.
+            updateBusinessDate("30 June 2026");
+            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoanDetails(loanId);
+            assertEquals(0.0, Utils.getDoubleValue(loan.getSummary().getPenaltyChargesOutstanding()), 0.0001,
+                    "Scheduled job must NOT charge on 30 June: working-day grace runs to 01 July");
+
+            // (2) Business date 01 July = the 5th working day after the 21 June due date. Penalty applies.
+            updateBusinessDate("01 July 2026");
+            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            loan = loanTransactionHelper.getLoanDetails(loanId);
+            assertTrue(Utils.getDoubleValue(loan.getSummary().getPenaltyChargesOutstanding()) > 0,
+                    "Scheduled job should charge on 01 July (5th working day after the 21 June due date)");
+        });
+    }
+
+    /**
      * Test 3: Verify MNZL 30/360 interest formula across all repayment periods.
      *
      * Each period's interest must equal outstanding_principal * 12% * 30/360 (i.e., 1% monthly rate). This validates
@@ -245,6 +370,42 @@ public class MnzlDecliningBalanceLoanIntegrationTest extends BaseLoanIntegration
 
     private List<GetLoansLoanIdRepaymentPeriod> getRepaymentPeriods(GetLoansLoanIdResponse loanDetails) {
         return loanDetails.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() > 0).toList();
+    }
+
+    private LocalDate firstInstallmentDueDate(GetLoansLoanIdResponse loanDetails) {
+        return loanDetails.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 1).findFirst()
+                .orElseThrow().getDueDate();
+    }
+
+    private void setWorkingDays(String recurrence, int repaymentRescheduleType) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("recurrence", recurrence);
+        body.put("locale", "en");
+        body.put("repaymentRescheduleType", repaymentRescheduleType);
+        body.put("extendTermForDailyRepayments", false);
+        Utils.performServerPut(requestSpec, responseSpec, "/fineract-provider/api/v1/workingdays?" + Utils.TENANT_IDENTIFIER,
+                new Gson().toJson(body), "");
+    }
+
+    private void createAndActivateHoliday(String fromDate, String toDate) {
+        Map<String, Object> office = new HashMap<>();
+        office.put("officeId", "1");
+        List<Map<String, Object>> offices = new ArrayList<>();
+        offices.add(office);
+        Map<String, Object> body = new HashMap<>();
+        body.put("offices", offices);
+        body.put("locale", "en");
+        body.put("dateFormat", DATETIME_PATTERN);
+        // Name is unique to dodge the m_holiday.name constraint across reruns; it does not affect grace behaviour.
+        body.put("name", Utils.uniqueRandomStringGenerator("testing_", 5));
+        body.put("fromDate", fromDate);
+        body.put("toDate", toDate);
+        body.put("reschedulingType", 1); // RESCHEDULE_TO_NEXT_REPAYMENT_DATE (matches staging); no due date hits the
+                                         // holiday window
+        Integer holidayId = Utils.performServerPost(requestSpec, responseSpec,
+                "/fineract-provider/api/v1/holidays?" + Utils.TENANT_IDENTIFIER, new Gson().toJson(body), "resourceId");
+        Utils.performServerPost(requestSpec, responseSpec,
+                "/fineract-provider/api/v1/holidays/" + holidayId + "?command=activate&" + Utils.TENANT_IDENTIFIER, "{}", "resourceId");
     }
 
     private PostLoanProductsResponse createMnzlDecliningBalanceProduct() {


### PR DESCRIPTION
## Summary

Follow-up to #24. Overdue penalties have **two** entry points and #24 only covered one:

| Path | Working-day aware before this PR? |
|------|-----------------------------------|
| COB step `APPLY_CHARGE_TO_OVERDUE_LOANS` | ✅ (#24) |
| Scheduled job **"Apply penalty to overdue loans"** (`APPLY_CHARGE_TO_OVERDUE_LOAN_INSTALLMENT`) | ❌ — calendar days |

The scheduled job's `retrieveAllLoansWithOverdueInstallments` query selects installments using calendar-day `penaltyWaitPeriod`, so it charged penalties on weekends/holidays (observed on staging).

**Fix:** `MnzlOverdueChargeGraceAspect` — an `@Around` advice on the single shared chokepoint `LoanChargeWritePlatformService.applyOverdueChargesForLoan(...)` that drops any installment whose **working-day** grace (skipping weekends per `m_working_days` + active `m_holiday` for the loan's office) hasn't elapsed. Covers **both** paths. Gated by `mnzl.loan.grace.workingDays.enabled`. Mirrors the existing `FlushModeAspect` AOP pattern.

**Caveat (documented on the aspect):** with `backdate-penalties-enabled = false` the scheduled job's query only surfaces an installment on its exact calendar-grace day, so the advice can't push that one config to the later working-day date; the COB-step path handles backdate-disabled correctly. Staging/prod runs backdate **enabled**, where it works.

## Test plan

- [x] `MnzlOverdueChargeGraceAspectTest` — unit tests (withhold during grace / apply once elapsed / empty passthrough).
- [x] **E2E, ran locally against a real server+DB:** `MnzlDecliningBalanceLoanIntegrationTest`
  - `testOverduePenaltyGraceCountsWorkingDaysSkippingWeekendsAndHolidays` — drives the COB step via inline COB.
  - `testScheduledJobOverduePenaltyHonoursWorkingDayGrace` — runs the **actual** "Apply penalty to overdue loans" scheduled job (the job run on staging).
  - Both replay staging loan 39550 (Sun–Thu week, `penalty-wait-period=5`, holiday 24–28 June, first installment due Sun 21 June) and assert **no penalty before the 5th working day (01 July)** and a **penalty on/after it**. Both PASSED.