### PR TITLE
[codex] Fix trial balance created date mapping

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTasklet.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTasklet.java
@@ -86,13 +86,20 @@ public class UpdateTrialBalanceDetailsTasklet implements Tasklet {
         tb.setOfficeId((Long) row[0]);
         tb.setGlAccountId((Long) row[1]);
         tb.setAmount((BigDecimal) row[2]);
-        tb.setEntryDate(toLocalDate(row[3]));
-        tb.setTransactionDate(toLocalDate(row[4]));
+        tb.setEntryDate(toLocalDate(row[3], "transactionDate", true));
+        tb.setTransactionDate(toLocalDate(row[4], "createdDate", false));
         tb.setClosingBalance((BigDecimal) row[5]);
         return tb;
     }
 
-    private LocalDate toLocalDate(Object value) {
+    private LocalDate toLocalDate(Object value, String fieldName, boolean required) {
+        if (value == null) {
+            if (required) {
+                throw new IllegalArgumentException("Expected date-like value for " + fieldName + " but got null");
+            }
+            log.warn("Null {} value while mapping trial balance row; saving null date", fieldName);
+            return null;
+        }
         if (value instanceof LocalDate localDate) {
             return localDate;
         }
@@ -102,7 +109,7 @@ public class UpdateTrialBalanceDetailsTasklet implements Tasklet {
         if (value instanceof LocalDateTime localDateTime) {
             return localDateTime.toLocalDate();
         }
-        throw new IllegalArgumentException("Expected date-like value but got " + (value == null ? "null" : value.getClass().getName()));
+        throw new IllegalArgumentException("Expected date-like value for " + fieldName + " but got " + value.getClass().getName());
     }
 
     private void updateClosingBalances(JdbcTemplate jdbcTemplate) {

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTasklet.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTasklet.java
@@ -20,6 +20,8 @@ package org.apache.fineract.accounting.glaccount.jobs.updatetrialbalancedetails;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,21 +73,36 @@ public class UpdateTrialBalanceDetailsTasklet implements Tasklet {
     private void insertTrialBalanceForDate(LocalDate tbGap) {
         List<Object[]> rows = journalEntryRepository.findTrialBalanceLinesForDate(tbGap);
 
-        List<TrialBalance> trialBalances = rows.stream().map(row -> {
-            TrialBalance tb = new TrialBalance();
-            tb.setOfficeId((Long) row[0]);
-            tb.setGlAccountId((Long) row[1]);
-            tb.setAmount((BigDecimal) row[2]);
-            tb.setEntryDate((LocalDate) row[3]);
-            tb.setTransactionDate((LocalDate) row[4]);
-            tb.setClosingBalance((BigDecimal) row[5]);
-            return tb;
-        }).toList();
+        List<TrialBalance> trialBalances = rows.stream().map(this::mapTrialBalance).toList();
 
         trialBalanceRepositoryWrapper.save(trialBalances);
 
         log.debug("{}: Records affected by updateTrialBalanceDetails: {}", ThreadLocalContextUtil.getTenant().getName(),
                 trialBalances.size());
+    }
+
+    private TrialBalance mapTrialBalance(Object[] row) {
+        TrialBalance tb = new TrialBalance();
+        tb.setOfficeId((Long) row[0]);
+        tb.setGlAccountId((Long) row[1]);
+        tb.setAmount((BigDecimal) row[2]);
+        tb.setEntryDate(toLocalDate(row[3]));
+        tb.setTransactionDate(toLocalDate(row[4]));
+        tb.setClosingBalance((BigDecimal) row[5]);
+        return tb;
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof OffsetDateTime offsetDateTime) {
+            return offsetDateTime.toLocalDate();
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime.toLocalDate();
+        }
+        throw new IllegalArgumentException("Expected date-like value but got " + (value == null ? "null" : value.getClass().getName()));
     }
 
     private void updateClosingBalances(JdbcTemplate jdbcTemplate) {

--- a/fineract-accounting/src/test/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTaskletTest.java
+++ b/fineract-accounting/src/test/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTaskletTest.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.accounting.glaccount.jobs.updatetrialbalancedetails;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.fineract.accounting.glaccount.domain.TrialBalance;
+import org.apache.fineract.accounting.glaccount.domain.TrialBalanceRepository;
+import org.apache.fineract.accounting.glaccount.domain.TrialBalanceRepositoryWrapper;
+import org.apache.fineract.accounting.journalentry.domain.JournalEntryRepository;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.core.service.database.RoutingDataSourceService;
+import org.apache.fineract.infrastructure.core.service.database.RoutingDataSourceServiceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateTrialBalanceDetailsTaskletTest {
+
+    private static final LocalDate BUSINESS_DATE = LocalDate.of(2026, 2, 3);
+
+    @Mock
+    private RoutingDataSourceServiceFactory dataSourceServiceFactory;
+
+    @Mock
+    private RoutingDataSourceService dataSourceService;
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private TrialBalanceRepositoryWrapper trialBalanceRepositoryWrapper;
+
+    @Mock
+    private TrialBalanceRepository trialBalanceRepository;
+
+    @Mock
+    private JournalEntryRepository journalEntryRepository;
+
+    @Mock
+    private StepContribution stepContribution;
+
+    @Mock
+    private ChunkContext chunkContext;
+
+    private UpdateTrialBalanceDetailsTasklet underTest;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(Map.of(BusinessDateType.BUSINESS_DATE, BUSINESS_DATE)));
+
+        underTest = new UpdateTrialBalanceDetailsTasklet(dataSourceServiceFactory, trialBalanceRepositoryWrapper, trialBalanceRepository,
+                journalEntryRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    void executeConvertsOffsetCreatedDateToLocalDateWhenSavingTrialBalance() throws Exception {
+        LocalDate transactionDate = LocalDate.of(2026, 2, 1);
+        OffsetDateTime createdDate = OffsetDateTime.of(2026, 2, 2, 18, 30, 0, 0, ZoneOffset.UTC);
+        Object[] trialBalanceRow = { 10L, 20L, new BigDecimal("12.34"), transactionDate, createdDate, new BigDecimal("56.78") };
+        ArgumentCaptor<List<TrialBalance>> trialBalancesCaptor = ArgumentCaptor.captor();
+
+        when(dataSourceServiceFactory.determineDataSourceService()).thenReturn(dataSourceService);
+        when(dataSourceService.retrieveDataSource()).thenReturn(dataSource);
+        when(trialBalanceRepository.findMaxCreatedDate()).thenReturn(LocalDate.of(2026, 1, 31));
+        when(journalEntryRepository.findTransactionDatesAfter(LocalDate.of(2026, 1, 31))).thenReturn(List.of(transactionDate));
+        when(journalEntryRepository.findTrialBalanceLinesForDate(transactionDate)).thenReturn(List.<Object[]>of(trialBalanceRow));
+        when(trialBalanceRepository.findDistinctOfficeIdsWithNullClosingBalance()).thenReturn(List.of());
+
+        assertEquals(RepeatStatus.FINISHED, underTest.execute(stepContribution, chunkContext));
+
+        verify(trialBalanceRepositoryWrapper).save(trialBalancesCaptor.capture());
+        List<TrialBalance> trialBalances = trialBalancesCaptor.getValue();
+        assertEquals(1, trialBalances.size());
+        TrialBalance trialBalance = trialBalances.getFirst();
+        assertEquals(transactionDate, trialBalance.getEntryDate());
+        assertEquals(createdDate.toLocalDate(), trialBalance.getTransactionDate());
+    }
+}

--- a/fineract-accounting/src/test/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTaskletTest.java
+++ b/fineract-accounting/src/test/java/org/apache/fineract/accounting/glaccount/jobs/updatetrialbalancedetails/UpdateTrialBalanceDetailsTaskletTest.java
@@ -19,11 +19,14 @@
 package org.apache.fineract.accounting.glaccount.jobs.updatetrialbalancedetails;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -101,6 +104,49 @@ class UpdateTrialBalanceDetailsTaskletTest {
     void executeConvertsOffsetCreatedDateToLocalDateWhenSavingTrialBalance() throws Exception {
         LocalDate transactionDate = LocalDate.of(2026, 2, 1);
         OffsetDateTime createdDate = OffsetDateTime.of(2026, 2, 2, 18, 30, 0, 0, ZoneOffset.UTC);
+
+        TrialBalance trialBalance = executeWithCreatedDate(transactionDate, createdDate);
+
+        assertEquals(transactionDate, trialBalance.getEntryDate());
+        assertEquals(createdDate.toLocalDate(), trialBalance.getTransactionDate());
+    }
+
+    @Test
+    void executeConvertsLocalDateTimeCreatedDateToLocalDateWhenSavingTrialBalance() throws Exception {
+        LocalDate transactionDate = LocalDate.of(2026, 2, 1);
+        LocalDateTime createdDate = LocalDateTime.of(2026, 2, 2, 18, 30, 0);
+
+        TrialBalance trialBalance = executeWithCreatedDate(transactionDate, createdDate);
+
+        assertEquals(transactionDate, trialBalance.getEntryDate());
+        assertEquals(createdDate.toLocalDate(), trialBalance.getTransactionDate());
+    }
+
+    @Test
+    void executeAllowsNullCreatedDateWhenSavingTrialBalance() throws Exception {
+        LocalDate transactionDate = LocalDate.of(2026, 2, 1);
+
+        TrialBalance trialBalance = executeWithCreatedDate(transactionDate, null);
+
+        assertEquals(transactionDate, trialBalance.getEntryDate());
+        assertNull(trialBalance.getTransactionDate());
+    }
+
+    @Test
+    void executeRejectsUnsupportedCreatedDateType() {
+        LocalDate transactionDate = LocalDate.of(2026, 2, 1);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> executeWithCreatedDate(transactionDate, "2026-02-02", false));
+
+        assertEquals("Expected date-like value for createdDate but got java.lang.String", exception.getMessage());
+    }
+
+    private TrialBalance executeWithCreatedDate(LocalDate transactionDate, Object createdDate) throws Exception {
+        return executeWithCreatedDate(transactionDate, createdDate, true);
+    }
+
+    private TrialBalance executeWithCreatedDate(LocalDate transactionDate, Object createdDate, boolean expectSuccess) throws Exception {
         Object[] trialBalanceRow = { 10L, 20L, new BigDecimal("12.34"), transactionDate, createdDate, new BigDecimal("56.78") };
         ArgumentCaptor<List<TrialBalance>> trialBalancesCaptor = ArgumentCaptor.captor();
 
@@ -109,15 +155,15 @@ class UpdateTrialBalanceDetailsTaskletTest {
         when(trialBalanceRepository.findMaxCreatedDate()).thenReturn(LocalDate.of(2026, 1, 31));
         when(journalEntryRepository.findTransactionDatesAfter(LocalDate.of(2026, 1, 31))).thenReturn(List.of(transactionDate));
         when(journalEntryRepository.findTrialBalanceLinesForDate(transactionDate)).thenReturn(List.<Object[]>of(trialBalanceRow));
-        when(trialBalanceRepository.findDistinctOfficeIdsWithNullClosingBalance()).thenReturn(List.of());
+        if (expectSuccess) {
+            when(trialBalanceRepository.findDistinctOfficeIdsWithNullClosingBalance()).thenReturn(List.of());
+        }
 
         assertEquals(RepeatStatus.FINISHED, underTest.execute(stepContribution, chunkContext));
 
         verify(trialBalanceRepositoryWrapper).save(trialBalancesCaptor.capture());
         List<TrialBalance> trialBalances = trialBalancesCaptor.getValue();
         assertEquals(1, trialBalances.size());
-        TrialBalance trialBalance = trialBalances.getFirst();
-        assertEquals(transactionDate, trialBalance.getEntryDate());
-        assertEquals(createdDate.toLocalDate(), trialBalance.getTransactionDate());
+        return trialBalances.getFirst();
     }
 }


### PR DESCRIPTION
## What changed
- Convert date-like values while mapping raw trial-balance query rows into `TrialBalance` entities.
- Preserve existing `LocalDate` behavior and handle `OffsetDateTime`/`LocalDateTime` by storing their local date component.
- Add a focused `UpdateTrialBalanceDetailsTasklet` regression test covering a `LocalDate` transaction date and `OffsetDateTime` created date.

## Root cause
`JournalEntryRepository.findTrialBalanceLinesForDate()` selects `je.createdDate` into row slot 4, and `JournalEntry.createdDate` is an `OffsetDateTime` from the auditable base class. `UpdateTrialBalanceDetailsTasklet` previously cast that slot directly to `LocalDate`, causing the staging `ClassCastException`.

## Validation
- `./gradlew :fineract-accounting:test --tests org.apache.fineract.accounting.glaccount.jobs.updatetrialbalancedetails.UpdateTrialBalanceDetailsTaskletTest`
- `./gradlew :fineract-accounting:spotlessCheck :fineract-accounting:check`
- `./gradlew :fineract-accounting:build`
- `git diff --check`