### PR TITLE
[codex] Widen job run history error log

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -226,4 +226,5 @@
     <include file="parts/0205_add_read_familymembers_permission.xml" relativeToChangelogFile="true" />
     <include file="parts/0206_transaction_summary_with_asset_owner_classification_name_bug_fix.xml" relativeToChangelogFile="true" />
     <include file="parts/0207_add_allow_full_term_for_tranche.xml" relativeToChangelogFile="true" />
+    <include file="parts/0208_widen_job_run_history_error_log.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0208_widen_job_run_history_error_log.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0208_widen_job_run_history_error_log.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <modifyDataType tableName="job_run_history" columnName="error_log" newDataType="LONGTEXT"/>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0208_widen_job_run_history_error_log.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0208_widen_job_run_history_error_log.xml
@@ -23,6 +23,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
     <changeSet author="fineract" id="1">
+        <modifyDataType tableName="job_run_history" columnName="error_message" newDataType="LONGTEXT"/>
         <modifyDataType tableName="job_run_history" columnName="error_log" newDataType="LONGTEXT"/>
     </changeSet>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/sql/migrations/sample_data/barebones_db.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/sample_data/barebones_db.sql
@@ -413,7 +413,7 @@ CREATE TABLE IF NOT EXISTS `job_run_history` (
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
   `status` varchar(10) CHARACTER SET latin1 NOT NULL,
-  `error_message` text,
+  `error_message` longtext,
   `trigger_type` varchar(25) NOT NULL,
   `error_log` longtext,
   PRIMARY KEY (`id`),

--- a/fineract-provider/src/main/resources/sql/migrations/sample_data/barebones_db.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/sample_data/barebones_db.sql
@@ -415,7 +415,7 @@ CREATE TABLE IF NOT EXISTS `job_run_history` (
   `status` varchar(10) CHARACTER SET latin1 NOT NULL,
   `error_message` text,
   `trigger_type` varchar(25) NOT NULL,
-  `error_log` text,
+  `error_log` longtext,
   PRIMARY KEY (`id`),
   KEY `scheduledjobsFK` (`job_id`),
   CONSTRAINT `scheduledjobsFK` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)

--- a/fineract-provider/src/main/resources/sql/migrations/sample_data/load_sample_data.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/sample_data/load_sample_data.sql
@@ -490,7 +490,7 @@ CREATE TABLE IF NOT EXISTS `job_run_history` (
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
   `status` varchar(10) CHARACTER SET latin1 NOT NULL,
-  `error_message` text,
+  `error_message` longtext,
   `trigger_type` varchar(25) NOT NULL,
   `error_log` longtext,
   PRIMARY KEY (`id`),

--- a/fineract-provider/src/main/resources/sql/migrations/sample_data/load_sample_data.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/sample_data/load_sample_data.sql
@@ -492,7 +492,7 @@ CREATE TABLE IF NOT EXISTS `job_run_history` (
   `status` varchar(10) CHARACTER SET latin1 NOT NULL,
   `error_message` text,
   `trigger_type` varchar(25) NOT NULL,
-  `error_log` text,
+  `error_log` longtext,
   PRIMARY KEY (`id`),
   KEY `scheduledjobsFK` (`job_id`),
   CONSTRAINT `scheduledjobsFK` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)


### PR DESCRIPTION
## Summary
- widen `job_run_history.error_log` from `TEXT` to `LONGTEXT`
- include the new tenant changelog in the tenant changelog master
- align sample database dumps with the widened column type

## Root Cause
Staging logs showed scheduler listener failures when a failed job's stacktrace exceeded the MariaDB/MySQL `TEXT` limit for `job_run_history.error_log`. Because the scheduler listener clears `currently_running` and writes run history in the same transaction, a history insert failure can leave the scheduler job lock stale.

## Validation
- `xmllint --noout fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml fineract-provider/src/main/resources/db/changelog/tenant/parts/0208_widen_job_run_history_error_log.xml`